### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/flatpak/com.core447.StreamController.metainfo.xml
+++ b/flatpak/com.core447.StreamController.metainfo.xml
@@ -4,9 +4,9 @@
 <component type="desktop-application">
   <id>com.core447.StreamController</id>
 
-  <developer_name translatable="no">Core447</developer_name>
+  <developer_name translate="no">Core447</developer_name>
   <developer id="com.core447">
-    <name translatable="no">Core447</name>
+    <name translate="no">Core447</name>
   </developer>
 
   <launchable type="desktop-id">com.core447.StreamController.desktop</launchable>
@@ -42,121 +42,121 @@
   <url type="contribute">https://github.com/StreamController/StreamController</url>
   <releases>
     <release version="1.4.8-beta" date="2024-04-09">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.4.7-beta" date="2024-04-08">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.4.6-beta" date="2024-04-08">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
         <p>Memory optimizations</p>
       </description>
     </release>
     <release version="1.4.5-beta" date="2024-04-02">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.4.4-beta" date="2024-04-02">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.4.3-beta" date="2024-04-02">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.4.2-beta" date="2024-04-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.4.1-beta" date="2024-04-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.4.0-beta" date="2024-04-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.3.9-beta" date="2024-04-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.3.8-beta" date="2024-04-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.3.7-beta" date="2024-04-01">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.3.6-beta" date="2024-03-31">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.3.5-beta" date="2024-03-31">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.3.4-beta" date="2024-03-31">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
         <p>Bundle icons</p>
       </description>
     </release>
     <release version="1.3.3-beta" date="2024-03-30">
-      <description translatable="no">
+      <description translate="no">
         <p>Switch to system icons for the settings</p>
       </description>
     </release>
     <release version="1.3.2-beta" date="2024-03-30">
-      <description translatable="no">
+      <description translate="no">
         <p>Switch to system icons for the settings</p>
       </description>
     </release>
     <release version="1.3.1-beta" date="2024-03-30">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.3.0-beta" date="2024-03-30">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
         <p>New page manager</p>
       </description>
     </release>
     <release version="1.2.1-beta" date="2024-03-27">
-      <description translatable="no">
+      <description translate="no">
         <p>Bugfixes</p>
       </description>
     </release>
     <release version="1.2.0-beta" date="2024-03-27">
-      <description translatable="no">
+      <description translate="no">
         <p>First beta release</p>
         <p>Bug fixes</p>
       </description>
     </release>
     <release version="1.2.0-alpha" date="2024-03-27">
-      <description translatable="no">
+      <description translate="no">
         <p>First release</p>
       </description>
     </release>
     <release version="1.1.2-alpha" date="2024-03-25">
-      <description translatable="no">
+      <description translate="no">
         <p>First test release</p>
       </description>
     </release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html