### PR TITLE
Created first implementation for Plugin Events

### DIFF
--- a/src/backend/PluginManager/EventHolder.py
+++ b/src/backend/PluginManager/EventHolder.py
@@ -1,0 +1,43 @@
+import asyncio
+from loguru import logger as log
+
+class EventHolder:
+    """
+        Holder for Event Callbacks for the specified Event ID
+    """
+    def __init__(self, plugin_base: "PluginBase", event_id: str):
+        if event_id in ["", None]:
+            raise ValueError("Please specify an signal id")
+
+        self.plugin_base = plugin_base
+        self.event_id = event_id
+        self.observers: list = []
+
+    def add_listener(self, callback: callable):
+        if callback not in self.observers:
+            self.observers.append(callback)
+        else:
+            log.warning(f"Callback {callback.__name__} is already subscribed to: {self.event_id}")
+
+    def remove_listener(self, callback: callable):
+        if callback in self.observers:
+            self.observers.remove(callback)
+
+    def trigger_event(self, *args, **kwargs):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(self._run_event(self.event_id, *args, **kwargs))
+
+    async def _run_event(self, *args, **kwargs):
+        coroutines = [self._ensure_coroutine(observer, *args, **kwargs) for observer in self.observers]
+        await asyncio.gather(*coroutines)
+
+    async def _ensure_coroutine(self, callback: callable, *args, **kwargs):
+        if asyncio.iscoroutinefunction(callback):
+            return await callback(*args, **kwargs)
+        else:
+            try:
+                return await asyncio.to_thread(callback, *args, **kwargs)
+            except Exception as e:
+                log.error(f"Callback {callback.__name__} in {self.event_id} could not be called")
+                return await asyncio.sleep(0)

--- a/src/backend/PluginManager/PluginBase.py
+++ b/src/backend/PluginManager/PluginBase.py
@@ -205,6 +205,9 @@ class PluginBase(rpyc.Service):
         except Exception as e:
             log.error(e)
 
+    def get_plugin(self, plugin_id: str):
+        return gl.plugin_manager.get_plugin_by_id(plugin_id) or None
+
     # ---------- #
     # Rpyc stuff #
     # ---------- #

--- a/src/backend/PluginManager/PluginBase.py
+++ b/src/backend/PluginManager/PluginBase.py
@@ -160,7 +160,7 @@ class PluginBase(rpyc.Service):
         else:
             log.warning(f"{event_id} does not exist in {self.plugin_name}")
 
-    def connect_event_directly(self, plugin_id: str, event_id: str, callback: callable) -> None:
+    def connect_to_event_directly(self, plugin_id: str, event_id: str, callback: callable) -> None:
         """
         Connects a Callback directly to a Plugin with the specified ID
 


### PR DESCRIPTION
Plugins can now Create Custom Events just like ActionHolders.
Events can be triggered by the Plugin itself by providing the specified ID
Events follow the Conventions of ActionHolders (An Event ID has to be specified)

The Events themselves implement the Observer pattern in an asynchronous way.
After a callback got connected to the Event, when it triggers the callback will be called async, when the callback is not specified as async a thread will be used to run the callback.
When this fails an error gets thrown and a async wait with a delay of 0 gets used instead to not disrupt the flow of the program.

I found no problems by always creating a new event loop, bigger scale tests may need to be run. Reverting the Changes is easy when it disrupts the program to much
