### PR TITLE
build: Add semantic release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Release
+on:
+  workflow_dispatch:
+  push:
+    - main
+    - beta
+    - alpha
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.semrel.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: go-semantic-release/action@v1
+        id: semrel
+        name: Release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,7 @@ vid_cache/
 **/.flatpak/
 
 .flatpak/meson.sh
+
+## Semrel temporary stuff
+.semrel/
+semantic-release


### PR DESCRIPTION
Adds a release workflow to automate versioning and release notes. 
This workflow uses the [go semantic release action](https://github.com/go-semantic-release/semantic-release) and will automatically calculate version based on [semver conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), create a new release and add the release notes to it. 

The workflow sets an output with the version that can be used on later jobs such as building flatpack with the same version. you can see an example of how I've done it for streamdeck-linux-gui [here](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui/blob/main/.github/workflows/release.yaml)

Considering that the versioning schema right now is not really conventional, I have added the custom arguments that will create beta versions from the main branch and will keep the version 1 as beta versions. Some tricks are required here until things are stable and ready to follow the convention.

It will Keep whatever is the last beta version you tagged, and will increment it, example:

`1.4.11-beta.1, 1.4.11-beta.2 ... 1.4.11-beta.10 ... 1.4.11-beta.n`

If you want to bump the beta version to something else, Just cut a new tag, for example, `1.5.0-beta.1` and from that moment on, the tool will start releasing based on 1.5. 

When you are ready to make a stable release, then you can just remove the custom arguments from the workflow, manually create a tag with what version you want to be the stable version and from that moment on, just let  the workflow take over. 

For now the workflow has to be triggered manually so you have time to adjust to it. you can add on push to the workflow whenever you are ready to let the workflow do it when PR ar merges or you push code. 
```
on:
  push:
    branches:
    - main
    - beta
    - alpha
```

you may have noticed that I have added `beta` and `alpha` branches there, the reason is that you can from that moment on start using a beta branch for beta releases, whenever you push code adhering to the conventional commit style, beta releases are made form that branch, same alpha.

You can preview how the tool behaves locally by downloading it like mentioned [here](https://github.com/go-semantic-release/semantic-release?tab=readme-ov-file#installation) and run it locally for example like this: 

```
GH_TOKEN="ghp_*********" ./semantic-release --dry --no-ci --provider-opt slug=streamcontroller/streamcontroller --allow-maintained-version-on-default-branch --maintained-version 1-beta
```

Please don't forget to add github actions permissions to access the token ...

![actions](https://github.com/StreamController/StreamController/assets/14358086/d6214774-95fd-4b76-9e50-aae07b8f021c)


Hit me up either here or on discord if you have any questions or need any further help :) 