### PR TITLE
Fixed some Critical Errors

### DIFF
--- a/src/backend/PluginManager/PluginBase.py
+++ b/src/backend/PluginManager/PluginBase.py
@@ -69,8 +69,8 @@ class PluginBase(rpyc.Service):
         self.plugin_name = plugin_name or manifest.get("name") or None
         self.github_repo = github_repo or manifest.get("github") or None
         self.plugin_version = plugin_version or manifest.get("version") or None
-        self.min_app_version = manifest.get("minimum-app-version") or None
-        self.app_version = app_version or manifest.get("app-version") or None
+        self.min_app_version = manifest.get("minimum-app-version") or "0.0.0" #TODO: IMPLEMENT BETTER WAY OF VERSION ERROR HANDLING
+        self.app_version = app_version or manifest.get("app-version") or "0.0.0"
 
         # Verify variables
         if self.plugin_name in ["", None]:
@@ -150,10 +150,12 @@ class PluginBase(rpyc.Service):
 
     def are_major_versions_matching(self) -> bool:
         app_version = version.parse(gl.app_version)
-        min_app_version = version.parse(self.min_app_version)
+        # Should use the current app version the plugin uses instead of the minimum app version
+        current_app_version = version.parse(self.app_version)
 
-        return app_version.major == min_app_version.major
-    
+        return app_version.major == current_app_version.major
+
+    #TODO: BETTER ERROR HANDLING FOR are_major_versions_matching and is_minimum_version_ok
     def is_app_version_matching(self) -> bool:
         return self.are_major_versions_matching() and self.is_minimum_version_ok()
 

--- a/src/windows/Store/StoreBackend.py
+++ b/src/windows/Store/StoreBackend.py
@@ -676,6 +676,9 @@ class StoreBackend:
             plugin.on_uninstall()
             
             ## 3. Remove plugin folder
+            if os.path.islink(plugin.PATH):
+                log.error(f"Plugin {plugin.plugin_name} is inside a Symlink! Cant be removed")
+                return
             shutil.rmtree(plugin.PATH)
 
         ## 4. Delete plugin base object

--- a/src/windows/Store/StoreBackend.py
+++ b/src/windows/Store/StoreBackend.py
@@ -54,7 +54,7 @@ class StoreBackend:
     STORE_REPO_URL = "https://github.com/StreamController/StreamController-Store" #"https://github.com/StreamController/StreamController-Store"
     STORE_CACHE_PATH = "Store/cache"
     # STORE_CACHE_PATH = os.path.join(gl.DATA_PATH, STORE_CACHE_PATH)
-    STORE_BRANCH = "testing"
+    STORE_BRANCH = "main"
 
 
     def __init__(self):
@@ -395,7 +395,7 @@ class StoreBackend:
             author=author or None,  # Formerly: user_name
             official=author in self.official_authors or False,
             commit_sha=commit,
-            local_sha=await self.get_local_sha(os.path.join(gl.DATA_PATH, "icons", manifest.get("id"))),
+            local_sha=await self.get_local_sha(os.path.join(gl.DATA_PATH, "icons", (manifest.get("id") or ""))),
             minimum_app_version=manifest.get("minimum-app-version") or None,
             app_version=manifest.get("app-version") or None,
             repository_name=self.get_repo_name(url),
@@ -449,7 +449,7 @@ class StoreBackend:
             author=author or None,  # Formerly: user_name
             official=author in self.official_authors or False,
             commit_sha=commit,
-            local_sha=await self.get_local_sha(os.path.join(gl.DATA_PATH, "plugins", manifest.get("id"))),
+            local_sha=await self.get_local_sha(os.path.join(gl.DATA_PATH, "plugins", (manifest.get("id") or ""))),
             minimum_app_version=manifest.get("minimum-app-version") or None,
             app_version=manifest.get("app-version") or None,
             repository_name=self.get_repo_name(url),


### PR DESCRIPTION
- When using main store branch plugins were not able to register at all because version checks were only done on the min_app_version
- Instead of setting min_app_version to None it will now be set to 0.0.0, this does basically the same as None but instead of exiting the function it will return True, which is expected behaviour when no min_app_version is provided
- Added an extra security layer when trying to get the local sha in the store backend. It threw an error when id was not present because None values are not allowed, not the path will just point to icons/ and nothing happens
- Added a check for symlinks when uninstalling a Plugin, only usefull in development and shouldnt do really do anything