### PR TITLE
Use fallback locale when can't parse locale

### DIFF
--- a/locales/LegacyLocaleManager.py
+++ b/locales/LegacyLocaleManager.py
@@ -35,7 +35,7 @@ class LegacyLocaleManager:
 
     def set_to_os_default(self):
         os_locale = locale.getlocale()[0]
-        self.set_language(os_locale)
+        self.set_language(self.FALLBACK_LOCALE if os_locale is None else os_locale)
 
     def set_language(self, language: str) -> str:
         language = self.get_best_match(language)

--- a/locales/LocaleManager.py
+++ b/locales/LocaleManager.py
@@ -45,7 +45,7 @@ class LocaleManager:
 
     def set_to_os_default(self):
         os_locale = locale.getlocale()[0]
-        self.set_language(os_locale)
+        self.set_language(self.FALLBACK_LOCALE if os_locale is None else os_locale)
 
     def get_best_match(self, preferred_language: str) -> str:
         # Get all available locales


### PR DESCRIPTION
When OS locale is invalid everything breaks so we should use the fallback when it comes back as None