### PR TITLE
flag to skip hardware init (eg. when drivers/libs are broken)

### DIFF
--- a/globals.py
+++ b/globals.py
@@ -8,6 +8,7 @@ from loguru import logger as log
 argparser = argparse.ArgumentParser()
 argparser.add_argument("-b", help="Open in background", action="store_true")
 argparser.add_argument("--devel", help="Developer mode (disables auto update)", action="store_true")
+argparser.add_argument("--skip-load-hardware-decks", help="Skips initilization/use of hardware decks", action="store_true")
 argparser.add_argument("--close-running", help="Close running", action="store_true")
 argparser.add_argument("--data", help="Data path", type=str)
 argparser.add_argument("--change-page", action="append", nargs=2, help="Change the page for a device", metavar=("SERIAL_NUMBER", "PAGE_NAME"))

--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -71,6 +71,12 @@ class DeckManager:
             resume_thread.start()
 
     def load_decks(self):
+        if not gl.argparser.parse_args().skip_load_hardware_decks:
+            self.load_hardware_decks()
+
+        self.load_fake_decks()
+
+    def load_hardware_decks(self):
         decks=DeviceManager().enumerate()
         for deck in decks:
             try:
@@ -84,9 +90,6 @@ class DeckManager:
                 continue
             deck_controller = DeckController(self, deck)
             self.deck_controller.append(deck_controller)
-
-        # Load fake decks
-        self.load_fake_decks()
 
     def load_fake_decks(self):
         old_n_fake_decks = len(self.fake_deck_controller)


### PR DESCRIPTION
I'm running on NixOS. And due to the way it handles dependencies, `ctypes.utils.find_library` (which gets used by the `StreamDeck` python lib) throws an error. Log for reference. 

```log
2024-06-23 15:07:45.886 | ERROR    | __main__:main:273 - An error has been caught in function 'main', process 'MainProcess' (206317), thread 'MainThread' (139761652938560):
Traceback (most recent call last):

  File "/nix/store/7hnr99nxrd2aw6lghybqdmkckq60j6l9-python3-3.11.9/lib/python3.11/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
           │         │     └ {'__name__': '__main__', '__doc__': None, '__package__': '', '__loader__': <_frozen_importlib_external.SourceFileLoader objec...
           │         └ <code object <module> at 0x7f1ccadeb470, file "/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy...
           └ <function _run_code at 0x7f1ccac52a20>
  File "/nix/store/7hnr99nxrd2aw6lghybqdmkckq60j6l9-python3-3.11.9/lib/python3.11/runpy.py", line 88, in _run_code
    exec(code, run_globals)
         │     └ {'__name__': '__main__', '__doc__': None, '__package__': '', '__loader__': <_frozen_importlib_external.SourceFileLoader objec...
         └ <code object <module> at 0x7f1ccadeb470, file "/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy...

  File "/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy-2024.6.0/share/vscode/extensions/ms-python.debugpy/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
    │   └ <function main at 0x7f1cc94ec400>
    └ <module 'debugpy.server.cli' from '/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy-2024.6.0/sh...

  File "/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy-2024.6.0/share/vscode/extensions/ms-python.debugpy/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
    └ <function run_file at 0x7f1cc94ec180>

  File "/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy-2024.6.0/share/vscode/extensions/ms-python.debugpy/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
    │     │        └ 'main.py'
    │     └ <function run_path at 0x7f1cc9f0ad40>
    └ <module '_pydevd_bundle.pydevd_runpy' from '/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy-20...

  File "/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy-2024.6.0/share/vscode/extensions/ms-python.debugpy/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
    return _run_module_code(code, init_globals, run_name,
           │                │     │             └ '__main__'
           │                │     └ None
           │                └ <code object <module> at 0x16657b0, file "main.py", line 1>
           └ <function _run_module_code at 0x7f1cc9f0a980>

  File "/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy-2024.6.0/share/vscode/extensions/ms-python.debugpy/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
    _run_code(code, mod_globals, init_globals,
    │         │     │            └ None
    │         │     └ {'__name__': '__main__', '__doc__': '\nAuthor: Core447\nYear: 2023\n\nThis program is free software: you can redistribute it ...
    │         └ <code object <module> at 0x16657b0, file "main.py", line 1>
    └ <function _run_code at 0x7f1cc9f0a520>

  File "/nix/store/nbxbsk49smfs30bqdxvpakmsgmcxyhnd-vscode-extension-ms-python-debugpy-2024.6.0/share/vscode/extensions/ms-python.debugpy/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
         │     └ {'__name__': '__main__', '__doc__': '\nAuthor: Core447\nYear: 2023\n\nThis program is free software: you can redistribute it ...
         └ <code object <module> at 0x16657b0, file "main.py", line 1>

  File "main.py", line 276, in <module>
    main()
    └ <function main at 0x7f1b8c760ea0>

> File "main.py", line 273, in main
    load()
    └ <function load at 0x7f1b8c73fd80>

  File "main.py", line 98, in load
    gl.deck_manager.load_decks()
    │  │            └ <function DeckManager.load_decks at 0x7f1b8c83e660>
    │  └ <src.backend.DeckManagement.DeckManager.DeckManager object at 0x7f1b8c7a2010>
    └ <module 'globals' from '/media/Data/Dev/git/StreamController/globals.py'>

  File "/media/Data/Dev/git/StreamController/src/backend/DeckManagement/DeckManager.py", line 75, in load_decks
    self.load_hardware_decks()
    │    └ <function DeckManager.load_hardware_decks at 0x7f1b8c83f7e0>
    └ <src.backend.DeckManagement.DeckManager.DeckManager object at 0x7f1b8c7a2010>

  File "/media/Data/Dev/git/StreamController/src/backend/DeckManagement/DeckManager.py", line 80, in load_hardware_decks
    decks=DeviceManager().enumerate()
          └ <class 'StreamDeck.DeviceManager.DeviceManager'>

  File "/media/Data/Dev/git/StreamController/.venv/lib/python3.11/site-packages/StreamDeck/DeviceManager.py", line 94, in __init__
    self.transport = self._get_transport(transport)
    │                │    │              └ None
    │                │    └ <staticmethod(<function DeviceManager._get_transport at 0x7f1cc90053a0>)>
    │                └ <StreamDeck.DeviceManager.DeviceManager object at 0x7f1b8dcf2490>
    └ <StreamDeck.DeviceManager.DeviceManager object at 0x7f1b8dcf2490>
  File "/media/Data/Dev/git/StreamController/.venv/lib/python3.11/site-packages/StreamDeck/DeviceManager.py", line 86, in _get_transport
    raise ProbeError("Probe failed to find any functional HID backend.", probe_errors)
          │                                                              └ {'libusb': TransportError("No suitable LibUSB HIDAPI library found on this system. Is the 'libhidapi-libusb.so' library insta...
          └ <class 'StreamDeck.DeviceManager.ProbeError'>

StreamDeck.DeviceManager.ProbeError: ('Probe failed to find any functional HID backend.', {'libusb': TransportError("No suitable LibUSB HIDAPI library found on this system. Is the 'libhidapi-libusb.so' library installed?")})
```

The libraries are installed ("the NixOS way"), but `ctypes` is unable to find them.
This is just in the "git-cloned version"  of StreamController, Flatpak works fine.

Since this is a issue between NixOS and ctypes, I only did minor adjustments. However maybe this is also useful for someone else in the future too? Like people new to Linux,  having trouble installing drivers/libs. Or someone using distrobox/dev-containers?

It's intended for use in development, however I did not want to link this to `--devel` directly as to no affect other people.