### PR TITLE
Feat(ui): add custom ComboRow wrapper for a simple ComboBox with static options

### DIFF
--- a/GtkHelper/StaticItemListComboRow.py
+++ b/GtkHelper/StaticItemListComboRow.py
@@ -1,0 +1,87 @@
+"""
+Author: GsakuL
+Year: 2024
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+any later version.
+
+This programm comes with ABSOLUTELY NO WARRANTY!
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from typing import Sequence
+
+import gi
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Gtk, Adw, Gio, GObject
+
+from loguru import logger as log
+
+
+class ListItem(GObject.Object):
+    def __init__(self, key: str, name: str):
+        super().__init__()
+        self._key = key
+        self._name = name
+
+    @GObject.Property(type=str)
+    def key(self):
+        return self._key
+    
+    @GObject.Property(type=str)
+    def name(self):
+        return self._name
+
+
+class StaticItemListComboRow(Adw.ComboRow):
+    """
+    A primitive wrapper, to make simple "combo box"-style selections.
+    You likely want to `.connect("notify::selected", ...)`, and then call `get_selected_item()` there,
+    to get the ListItem (key-name-pair) again
+
+    Based on https://discourse.gnome.org/t/migrate-from-comboboxtext-to-comborow-dropdown/10565/2
+    """
+
+    def __init__(self, items: Sequence[ListItem], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.__items: list[ListItem] = list(items)
+        model = Gio.ListStore(item_type=ListItem)
+        factory = Gtk.SignalListItemFactory()
+
+        keys = set()
+        for i in self.__items:
+            if i. key in keys:
+                raise ValueError(f"key '{i.key}' was given more than once in item list")
+            keys.add(i.key)
+            model.append(i)
+
+        factory.connect("setup", self.__on_factory_setup)
+        factory.connect("bind", self.__on_factory_bind)
+
+        self.set_model(model)
+        self.set_factory(factory)
+
+    def __on_factory_setup(self, factory, list_item):
+        label = Gtk.Label()
+        list_item.set_child(label)
+
+    def __on_factory_bind(self, factory, list_item):
+        label = list_item.get_child()
+        entry: ListItem = list_item.get_item()
+        label.set_text(entry.name)
+
+    def set_selected_item_by_key(self, key: str, *, default: int | None = None):
+        """
+        Call when loading user-settings, to pre-select the correkt ListItem
+        """
+        index_ = next((i for i, t in enumerate(self.__items) if t.key == key), default)
+        if index_ is None:
+            log.warning("key '{0}' was not found amongst item list, and no default was given", key)
+        else:
+            self.set_selected(index_)


### PR DESCRIPTION
while working on StreamController/Requests#2 it became clear, that a "combo box" style widget is not as easy as I thought.
Here is a pretty basic custom widget to wrap a few Adw/Gtk classes to provide a combo box for static items.
Items have keys to be stored in persistent settings, and have names, that can be localized.

- I wasn't sure who the 'Author' should be in the header, if it's you as the maintainer ("author of the project"), or me as the "author of the file".
- I could not find an already existing solution in the project, please excuse if there is
- I thought `widgets/` would be appropriate since it's intended to be "re-used anywhere"
- proper Enums and generics `[T]` would be better, but `GEnum` currently seems to be not supported, thus i though str keys are the most flexible and "user friendly" (instead of cryptic int values) for now
- as I did not write the core functionality, I put a link for a lack of better attribution 
- it would be nice to have this in the next release (so the Requests can depend on that), but I don't want to be pushy

(dirty) Example:
```py
def get_config_rows(self):
    _receive_types = [
        ListItem(k, lm.get(f"convert.list_item.{k}"))
        for k in ["json", "xml", "plain_text", "ignore"]
    ]
    self.receive_type = StaticItemListComboRow(
        _receive_types,
        title=lm.get("actions.get.receive_type.title"))
    self.receive_type.connect("notify::selected", self.on_receive_type_changed)

def on_receive_type_changed(self, entry, *args):
    settings = self.get_settings()
    settings["receive_type"] = entry.get_selected_item().key
    self.set_settings(settings)
```

and it would look like this (with localization)
![grafik](https://github.com/StreamController/StreamController/assets/6844160/daa7e023-dce8-404c-a0f2-a133ef2ce7fa)

Edit: could not get screenshots with mouse pointer and mouse over-effect, so here a small clip:
[example.webm](https://github.com/StreamController/StreamController/assets/6844160/c3da194d-6e0a-484e-8946-f94760853dab)
