### PR TITLE
fix(controller): Calls decode() when needed, and calls proper function for deck state

### DIFF
--- a/src/backend/PluginManager/ActionBase.py
+++ b/src/backend/PluginManager/ActionBase.py
@@ -202,8 +202,9 @@ class ActionBase(rpyc.Service):
         if not self.get_is_present(): return
         if self.get_is_multi_action(): return
         try:
-            self.get_input_state().show_error(duration=duration)
-        except AttributeError:
+            self.get_state().show_error(duration=duration)
+        except AttributeError as e:
+            log.error(e)
             pass
 
     def hide_error(self) -> None:
@@ -212,7 +213,7 @@ class ActionBase(rpyc.Service):
         if not self.get_is_present(): return
         if self.get_is_multi_action(): return
         try:
-            self.get_input_state().hide_error()
+            self.get_state().hide_error()
         except AttributeError:
             pass
 

--- a/src/backend/WindowGrabber/Integrations/X11.py
+++ b/src/backend/WindowGrabber/Integrations/X11.py
@@ -95,7 +95,7 @@ class X11(Integration):
             if root is None:
                 return
             stdout, stderr = root.communicate()
-            split = stdout.strip().split()
+            split = stdout.decode().strip().split()
             if len(split) == 0:
                 return
             window_id = split[-1]


### PR DESCRIPTION
All other methods of `communicate()` make sure to call `decode()` on the results since it's returned as a byte array by default. It was missing here, causing the application to constantly spit out "invalid window id 0x0"