### PR TITLE
Added default font for labels

### DIFF
--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -1210,7 +1210,7 @@ class LabelManager:
         if label.color is None:
             label.color = [255, 255, 255, 255]
         if label.font_name is None:
-            label.font_name = ""
+            label.font_name = "DejaVu Sans"
         if label.font_size is None:
             label.font_size = 15
 


### PR DESCRIPTION
When running StreamController I get a couple of log entries like:
`findfont: Font family [''] not found. Falling back to DejaVu Sans.`

I'm not exactly sure which labels are causing this, but I thought since DejaVu Sans is the fallback anyway, we might as well make it the default. Might be different on other systems but it should not break anything.