### PR TITLE
fix: icon store page(s) showing error

### DIFF
--- a/src/windows/Store/Icons/IconPage.py
+++ b/src/windows/Store/Icons/IconPage.py
@@ -123,7 +123,7 @@ class IconPreview(StorePreview):
 
         # Update info page
         self.icon_page.info_page.set_name(self.icon_data.icon_name)
-        self.icon_page.info_page.set_description(self.icon_data.descriptions)
+        self.icon_page.info_page.set_description(gl.lm.get_custom_translation(self.icon_data.descriptions))
         self.icon_page.info_page.set_author(self.icon_data.author)
         self.icon_page.info_page.set_version(self.icon_data.icon_version)
 

--- a/src/windows/Store/Icons/IconPage.py
+++ b/src/windows/Store/Icons/IconPage.py
@@ -123,7 +123,7 @@ class IconPreview(StorePreview):
 
         # Update info page
         self.icon_page.info_page.set_name(self.icon_data.icon_name)
-        self.icon_page.info_page.set_description(gl.lm.get_custom_translation(self.icon_data.descriptions))
+        self.icon_page.info_page.set_description(self.icon_data.description)
         self.icon_page.info_page.set_author(self.icon_data.author)
         self.icon_page.info_page.set_version(self.icon_data.icon_version)
 

--- a/src/windows/Store/InfoPage.py
+++ b/src/windows/Store/InfoPage.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
 
 from GtkHelper.GtkHelper import AttributeRow, OriginalURL
 
+# Import globals
+import globals as gl
+
 class InfoPage(Gtk.Box):
     def __init__(self, store_page:"StorePage"):
         super().__init__(orientation=Gtk.Orientation.VERTICAL,
@@ -118,10 +121,15 @@ class DescriptionRow(Adw.PreferencesRow):
                                            margin_start=15, margin_top=15, margin_end=15)
         self.main_box.append(self.description_label)
 
-    def set_description(self, description:str):
+    def set_description(self, description:dict):
         if description in [None, ""]:
-            description = "N/A"
-        self.description_label.set_text(description)
+            self.description_label.set_text("N/A")
+        else:
+            locale = gl.lm.language
+            if not locale in description:
+                locale = gl.lm.FALLBACK_LOCALE
+
+            self.description_label.set_text(description[locale])
 
     def set_title(self, title:str):
         if title in [None, ""]:

--- a/src/windows/Store/InfoPage.py
+++ b/src/windows/Store/InfoPage.py
@@ -123,16 +123,8 @@ class DescriptionRow(Adw.PreferencesRow):
 
     def set_description(self, description:str):
         if description in [None, ""]:
-            self.description_label.set_text("N/A")
-        else:
-            if isinstance(description, dict):
-                locale = gl.lm.language
-                if not locale in description:
-                    locale = gl.lm.FALLBACK_LOCALE
-
-                self.description_label.set_text(description[locale])
-            else:
-                self.description_label.set_text(description)
+            description = "N/A"
+        self.description_label.set_text(description)
 
     def set_title(self, title:str):
         if title in [None, ""]:

--- a/src/windows/Store/InfoPage.py
+++ b/src/windows/Store/InfoPage.py
@@ -121,15 +121,18 @@ class DescriptionRow(Adw.PreferencesRow):
                                            margin_start=15, margin_top=15, margin_end=15)
         self.main_box.append(self.description_label)
 
-    def set_description(self, description:dict):
+    def set_description(self, description:str):
         if description in [None, ""]:
             self.description_label.set_text("N/A")
         else:
-            locale = gl.lm.language
-            if not locale in description:
-                locale = gl.lm.FALLBACK_LOCALE
+            if isinstance(description, dict):
+                locale = gl.lm.language
+                if not locale in description:
+                    locale = gl.lm.FALLBACK_LOCALE
 
-            self.description_label.set_text(description[locale])
+                self.description_label.set_text(description[locale])
+            else:
+                self.description_label.set_text(description)
 
     def set_title(self, title:str):
         if title in [None, ""]:

--- a/src/windows/Store/Plugins/PluginPage.py
+++ b/src/windows/Store/Plugins/PluginPage.py
@@ -125,7 +125,7 @@ class PluginPreview(StorePreview):
 
         # Update info page
         self.plugin_page.info_page.set_name(self.plugin_data.plugin_name)
-        self.plugin_page.info_page.set_description(gl.lm.get_custom_translation(self.plugin_data.descriptions))
+        self.plugin_page.info_page.set_description(self.plugin_data.description)
         self.plugin_page.info_page.set_author(self.plugin_data.author)
         self.plugin_page.info_page.set_version(self.plugin_data.plugin_version)
 

--- a/src/windows/Store/Wallpapers/WallpaperPage.py
+++ b/src/windows/Store/Wallpapers/WallpaperPage.py
@@ -117,7 +117,7 @@ class WallpaperPreview(StorePreview):
 
         # Update info page
         self.wallpaper_page.info_page.set_name(self.wallpaper_data.get("wallpaper_name"))
-        self.wallpaper_page.info_page.set_description(self.wallpaper_data.get("description"))
+        self.wallpaper_page.info_page.set_description(self.wallpaper_data.description)
         self.wallpaper_page.info_page.set_author(self.wallpaper_data.get("user_name"))
         self.wallpaper_page.info_page.set_version(self.wallpaper_data.get("wallpaper_version"))
 


### PR DESCRIPTION
The `description` variable is returning a `dict` type. An example of the dict is below:
> {'en_US': 'Unofficial - Material Icons designed by Google.'}

This pull request changes the code to set the label to the user's locale from the dictionary, if it is found.

I also added a fallback because in the plugins tab of the store it returns a `string` instead of a `dict`.