### PR TITLE
Fixed StreamDeck not reconnecting

### DIFF
--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -42,7 +42,7 @@ from gi.repository import GLib, Xdp
 # Import globals
 import globals as gl
 
-VALID_VENDORS = ["Elgato", "Elgato_Systems"]
+ELGATO_VENDOR_ID = "0fd9"
 
 
 class DeckManager:
@@ -134,7 +134,7 @@ class DeckManager:
     def on_connect(self, device_id, device_info):
         log.info(f"Device {device_id} with info: {device_info} connected")
         # Check if it is a supported device
-        if device_info["ID_VENDOR"] not in VALID_VENDORS:
+        if device_info["ID_VENDOR_ID"] != ELGATO_VENDOR_ID:
             return
 
         self.connect_new_decks()
@@ -156,7 +156,7 @@ class DeckManager:
 
     def on_disconnect(self, device_id, device_info):
         log.info(f"Device {device_id} with info: {device_info} disconnected")
-        if device_info["ID_VENDOR"] not in VALID_VENDORS:
+        if device_info["ID_VENDOR_ID"] != ELGATO_VENDOR_ID:
             return
 
         for controller in self.deck_controller:

--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -42,6 +42,9 @@ from gi.repository import GLib, Xdp
 # Import globals
 import globals as gl
 
+VALID_VENDORS = ["Elgato", "Elgato_Systems"]
+
+
 class DeckManager:
     def __init__(self):
         #TODO: Maybe outsource some objects
@@ -131,9 +134,9 @@ class DeckManager:
     def on_connect(self, device_id, device_info):
         log.info(f"Device {device_id} with info: {device_info} connected")
         # Check if it is a supported device
-        if device_info["ID_VENDOR"] != "Elgato":
+        if device_info["ID_VENDOR"] not in VALID_VENDORS:
             return
-        
+
         self.connect_new_decks()
 
     def connect_new_decks(self):
@@ -153,7 +156,7 @@ class DeckManager:
 
     def on_disconnect(self, device_id, device_info):
         log.info(f"Device {device_id} with info: {device_info} disconnected")
-        if device_info["ID_VENDOR"] != "Elgato":
+        if device_info["ID_VENDOR"] not in VALID_VENDORS:
             return
 
         for controller in self.deck_controller:


### PR DESCRIPTION
At least on my system (Ubuntu 24.04), my Stream Deck Mini identifies with vendor name "Elgato_Systems", not "Elgato". So the `on_connect()` and `on_disconnect()` functions were never executed for me. I added "Elgato_Systems" as a valid vendor and now unplugging and reconnecting the StreamDeck works as expected.

Alternatively, you could just check for the string "Elgato" in the vendor name or check the actual vendor id, which should be identical on all systems.