### PR TITLE
POSIX Shell Compatibility

### DIFF
--- a/src/backend/PluginManager/ActionBase.py
+++ b/src/backend/PluginManager/ActionBase.py
@@ -440,12 +440,12 @@ class ActionBase(rpyc.Service):
         if open_in_terminal:
             command = "gnome-terminal -- bash -c '"
             if venv_path is not None:
-                command += f"source {venv_path}/bin/activate && "
+                command += f". {venv_path}/bin/activate && "
             command += f"python3 {backend_path} --port={port}; exec $SHELL'"
         else:
             command = ""
             if venv_path is not None:
-                command = f"source {venv_path}/bin/activate && "
+                command = f". {venv_path}/bin/activate && "
             command += f"python3 {backend_path} --port={port}"
 
         log.info(f"Launching backend: {command}")

--- a/src/backend/PluginManager/PluginBase.py
+++ b/src/backend/PluginManager/PluginBase.py
@@ -508,12 +508,12 @@ class PluginBase(rpyc.Service):
         if open_in_terminal:
             command = "gnome-terminal -- bash -c '"
             if venv_path is not None:
-                command += f"source {venv_path}/bin/activate && "
+                command += f". {venv_path}/bin/activate && "
             command += f"python3 {backend_path} --port={port}; exec $SHELL'"
         else:
             command = ""
             if venv_path is not None:
-                command = f"source {venv_path}/bin/activate && "
+                command = f". {venv_path}/bin/activate && "
             command += f"python3 {backend_path} --port={port}"
 
         log.info(f"Launching backend: {command}")


### PR DESCRIPTION
These two patches allow plugins with backends to function on systems where `/bin/sh` is a standard POSIX shell, rather than Bash.  They may be squashed before merging.

Fixes #192.