### PR TITLE
Housekeeping: keep page backups for one week at most

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,6 +122,7 @@ def create_global_objects():
     gl.media_manager = MediaManager()
     gl.asset_manager_backend = AssetManagerBackend()
     gl.page_manager = PageManagerBackend(gl.settings_manager)
+    gl.page_manager.remove_old_backups()
     gl.page_manager.backup_pages()
     gl.icon_pack_manager = IconPackManager()
     gl.wallpaper_pack_manager = WallpaperPackManager()

--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -42,7 +42,7 @@ from gi.repository import GLib, Xdp
 # Import globals
 import globals as gl
 
-VALID_VENDORS = ["Elgato", "Elgato_Systems"]
+ELGATO_VENDOR_ID = "0fd9"
 
 
 class DeckManager:
@@ -134,7 +134,7 @@ class DeckManager:
     def on_connect(self, device_id, device_info):
         log.info(f"Device {device_id} with info: {device_info} connected")
         # Check if it is a supported device
-        if device_info["ID_VENDOR"] not in VALID_VENDORS:
+        if device_info["ID_VENDOR_ID"] != ELGATO_VENDOR_ID:
             return
 
         self.connect_new_decks()
@@ -156,7 +156,7 @@ class DeckManager:
 
     def on_disconnect(self, device_id, device_info):
         log.info(f"Device {device_id} with info: {device_info} disconnected")
-        if device_info["ID_VENDOR"] not in VALID_VENDORS:
+        if device_info["ID_VENDOR_ID"] != ELGATO_VENDOR_ID:
             return
 
         for controller in self.deck_controller:

--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -42,6 +42,9 @@ from gi.repository import GLib, Xdp
 # Import globals
 import globals as gl
 
+VALID_VENDORS = ["Elgato", "Elgato_Systems"]
+
+
 class DeckManager:
     def __init__(self):
         #TODO: Maybe outsource some objects
@@ -131,9 +134,9 @@ class DeckManager:
     def on_connect(self, device_id, device_info):
         log.info(f"Device {device_id} with info: {device_info} connected")
         # Check if it is a supported device
-        if device_info["ID_VENDOR"] != "Elgato":
+        if device_info["ID_VENDOR"] not in VALID_VENDORS:
             return
-        
+
         self.connect_new_decks()
 
     def connect_new_decks(self):
@@ -153,7 +156,7 @@ class DeckManager:
 
     def on_disconnect(self, device_id, device_info):
         log.info(f"Device {device_id} with info: {device_info} disconnected")
-        if device_info["ID_VENDOR"] != "Elgato":
+        if device_info["ID_VENDOR"] not in VALID_VENDORS:
             return
 
         for controller in self.deck_controller:

--- a/src/backend/DeckManagement/HelperMethods.py
+++ b/src/backend/DeckManagement/HelperMethods.py
@@ -12,6 +12,7 @@ This programm comes with ABSOLUTELY NO WARRANTY!
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from datetime import datetime
 from functools import lru_cache
 import hashlib
 import os
@@ -311,3 +312,21 @@ def get_values_from_pango_font_description(desc: Pango.FontDescription) -> tuple
         font_style = "normal"
 
     return font_family, font_size, font_weight, font_style
+
+def get_sub_folders(parent: str) -> list[str]:
+    if not os.path.isdir(parent):
+        return []
+
+    return [folder for folder in os.listdir(parent) if os.path.isdir(os.path.join(parent, folder))]
+
+def sort_times(time_list):
+    """
+    Sort a list of datetime strings in ascending order.
+
+    Parameters:
+    time_list (list of str): List of datetime strings to be sorted.
+
+    Returns:
+    list of str: Sorted list of datetime strings.
+    """
+    return sorted(time_list, key=lambda x: datetime.fromisoformat(x))

--- a/src/backend/PageManagement/Page.py
+++ b/src/backend/PageManagement/Page.py
@@ -18,6 +18,8 @@ import os
 import json
 import threading
 import time
+from datetime import datetime, timedelta
+
 from loguru import logger as log
 from copy import copy
 import shutil
@@ -31,7 +33,8 @@ import globals as gl
 from src.backend.PluginManager.ActionBase import ActionBase
 from src.backend.DeckManagement.InputIdentifier import Input, InputIdentifier
 # Import typing
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
+
 if TYPE_CHECKING:
     from src.backend.DeckManagement.DeckController import LabelManager
     from src.backend.PluginManager.ActionHolder import ActionHolder
@@ -44,7 +47,7 @@ class Page:
 
         self.dict = {}
 
-        self.json_path = json_path
+        self.json_path: str = json_path
         self.deck_controller = deck_controller
 
         # Dir that contains all actions this allows us to keep them at reload
@@ -90,10 +93,11 @@ class Page:
         self.file_access_semaphore.release()
 
     def make_backup(self):
-        os.makedirs(os.path.join(gl.DATA_PATH, "pages","backups"), exist_ok=True)
+        backups_dir = os.path.join(gl.DATA_PATH, "pages", "backups")
+        os.makedirs(backups_dir, exist_ok=True)
 
         src_path = self.json_path
-        dst_path = os.path.join(gl.DATA_PATH, "pages","backups", os.path.basename(src_path))
+        dst_path = os.path.join(backups_dir, os.path.basename(src_path))
 
         # Check if json in src is valid
         with open(src_path) as f:
@@ -104,6 +108,23 @@ class Page:
                 return
 
         shutil.copy2(src_path, dst_path)
+
+        # Delete old backups
+        backups_list = sorted(get_sub_folders(backups_dir))
+
+        for folder in backups_list:
+            # Keep at least 3 backups
+            # new calculation on each iteration because a folder might have been deleted
+            current_backup_count = len(get_sub_folders(backups_dir))
+            if current_backup_count <= 3:
+                break
+
+            folder_path = os.path.join(backups_dir, folder)
+            folder_mtime = datetime.fromtimestamp(os.path.getmtime(folder_path))
+
+            if datetime.now() - folder_mtime > timedelta(weeks=1):
+                shutil.rmtree(folder_path)
+                log.debug(f"Deleted page backup: {folder_path}")
 
     def move_key_to_end(self, dictionary, key):
         if key in self.dict:
@@ -893,6 +914,11 @@ class Page:
 
         if update:
             self.update_input(identifier, state)
+
+
+def get_sub_folders(parent: str) -> List[str]:
+    return [folder for folder in os.listdir(parent) if os.path.isdir(os.path.join(parent, folder))]
+
 
 class NoActionHolderFound:
     def __init__(self, id: str, state: int, identifier: InputIdentifier = None):

--- a/src/backend/PageManagement/Page.py
+++ b/src/backend/PageManagement/Page.py
@@ -896,9 +896,6 @@ class Page:
 
 
 def get_sub_folders(parent: str) -> List[str]:
-    if not os.path.isdir(parent):
-        return []
-
     return [folder for folder in os.listdir(parent) if os.path.isdir(os.path.join(parent, folder))]
 
 

--- a/src/backend/PageManagement/Page.py
+++ b/src/backend/PageManagement/Page.py
@@ -917,6 +917,9 @@ class Page:
 
 
 def get_sub_folders(parent: str) -> List[str]:
+    if not os.path.isdir(parent):
+        return []
+
     return [folder for folder in os.listdir(parent) if os.path.isdir(os.path.join(parent, folder))]
 
 

--- a/src/backend/PageManagement/Page.py
+++ b/src/backend/PageManagement/Page.py
@@ -895,10 +895,6 @@ class Page:
             self.update_input(identifier, state)
 
 
-def get_sub_folders(parent: str) -> List[str]:
-    return [folder for folder in os.listdir(parent) if os.path.isdir(os.path.join(parent, folder))]
-
-
 class NoActionHolderFound:
     def __init__(self, id: str, state: int, identifier: InputIdentifier = None):
         self.id = id

--- a/src/backend/PageManagement/PageManagerBackend.py
+++ b/src/backend/PageManagement/PageManagerBackend.py
@@ -442,7 +442,7 @@ class PageManagerBackend:
 
         if len(sorted_backups) <= n_backups_to_keep:
             return
-
-        for backup in sorted_backups[n_backups_to_keep:]:
+        
+        for backup in sorted_backups[:-n_backups_to_keep]:
             shutil.rmtree(os.path.join(backup_dir, backup))
             log.info(f"Removed old page backups: {backup}")

--- a/src/backend/PageManagement/PageManagerBackend.py
+++ b/src/backend/PageManagement/PageManagerBackend.py
@@ -28,7 +28,7 @@ from src.Signals import Signals
 # Import own modules
 from src.backend.PageManagement.Page import Page
 from src.backend.PageManagement.DummyPage import DummyPage
-from src.backend.DeckManagement.HelperMethods import natural_sort, natural_sort_by_filenames, recursive_hasattr
+from src.backend.DeckManagement.HelperMethods import get_sub_folders, natural_sort, natural_sort_by_filenames, recursive_hasattr, sort_times
 
 # Import globals
 import globals as gl
@@ -430,3 +430,19 @@ class PageManagerBackend:
         for page in self.get_pages():
             backup_path = os.path.join(folder, os.path.basename(page))
             shutil.copy(page, backup_path)
+
+
+    def remove_old_backups(self) -> None:
+        n_backups_to_keep = 5
+
+        backup_dir = os.path.join(gl.DATA_PATH, "pages", "backups")
+
+        unsorted_backups = get_sub_folders(backup_dir)
+        sorted_backups = sort_times(unsorted_backups)
+
+        if len(sorted_backups) <= n_backups_to_keep:
+            return
+
+        for backup in sorted_backups[n_backups_to_keep:]:
+            shutil.rmtree(os.path.join(backup_dir, backup))
+            log.info(f"Removed old page backups: {backup}")


### PR DESCRIPTION
As the backup count for pages quickly rises (I have deleted several hundred backup folders; power users probably have more), I have added a mechanism to clean them up. Backup folders are now deleted after one week - but at least three backup folders are always kept.