### PR TITLE
Add support for screensaver under Cinnamon

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Available for GNOME, Hyprland and all X11 desktops, this feature allows you to a
 
 ## Auto-Lock
 
-Lock your Stream deck when your system is locked, preventing unwanted use from third parties (available on KDE and GNOME).
+Lock your Stream deck when your system is locked, preventing unwanted use from third parties (available on KDE and GNOME, and Cinnamon).
 
 ## Installation
 

--- a/com.core447.StreamController.yml
+++ b/com.core447.StreamController.yml
@@ -19,6 +19,7 @@ finish-args:
   - --talk-name=org.gnome.Shell               # Interact with Gnome - used to open the "Install extension" dialog
   - --talk-name=org.gnome.Shell.Extensions.StreamController
   - --talk-name=org.gnome.ScreenSaver
+  - --talk-name=org.cinnamon.ScreenSaver
   - --talk-name=org.freedesktop.ScreenSaver
   - --system-talk-name=org.freedesktop.UPower # Access to power management - used to get battery status
 

--- a/src/backend/LockScreenManager/Detectors/Cinnamon.py
+++ b/src/backend/LockScreenManager/Detectors/Cinnamon.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 import dbus
 from loguru import logger as log
 
-class GnomeLockScreenDetector(LockScreenDetector):
+class CinnamonLockScreenDetector(LockScreenDetector):
     def __init__(self, lock_screen_manager: "LockScreenManager"):
         self.lock_screen_manager: "LockScreenManager" = lock_screen_manager
 
@@ -43,9 +43,9 @@ class GnomeLockScreenDetector(LockScreenDetector):
             # Define the signal to listen to
             bus.add_signal_receiver(
                 self.screen_saver_active_changed,
-                dbus_interface="org.gnome.ScreenSaver",
+                dbus_interface="org.cinnamon.ScreenSaver",
                 signal_name="ActiveChanged",
-                path="/org/gnome/ScreenSaver"
+                path="/org/cinnamon/ScreenSaver"
             )
         except Exception as e:
             log.error(f"Failed to connect to D-Bus: {e}")

--- a/src/backend/LockScreenManager/LockScreenManager.py
+++ b/src/backend/LockScreenManager/LockScreenManager.py
@@ -14,6 +14,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import os
 from src.backend.LockScreenManager.Detectors.Gnome import GnomeLockScreenDetector
+from src.backend.LockScreenManager.Detectors.Cinnamon import CinnamonLockScreenDetector
 from src.backend.LockScreenManager.Detectors.KDE import KDELockScreenDetector
 from src.backend.LockScreenManager.LockScreenDetector import LockScreenDetector
 from loguru import logger as log
@@ -31,6 +32,8 @@ class LockScreenManager:
         env = self.get_active_environment()
         if env == "gnome":
             self.detector = GnomeLockScreenDetector(self)
+        elif env == "x-cinnamon":
+            self.detector = CinnamonLockScreenDetector(self)
         elif env == "kde":
             self.detector = KDELockScreenDetector(self)
 


### PR DESCRIPTION
This change adds support for locking the Stream Deck when run under the Cinnamon desktop environment.  Tested on Linux Mint 22 with Xorg.

This probably needs an additional change to work with Wayland/Cinnamon whenever that gets usable (I could not even lock the screen on Linux Mint Cinnamon Wayland when I tried it so they got some work to do yet).

closes #198 