### PR TITLE
fix: Add desktop entry for non-flatpak installations

### DIFF
--- a/autostart.py
+++ b/autostart.py
@@ -32,7 +32,7 @@ def setup_autostart(enable: bool = True):
             setup_autostart_flatpak(True)
 
         else:
-            setup_autostart_desktop_entry(True)
+            setup_autostart_desktop_entry(True, True)
 
     else:
         setup_autostart_flatpak(False)
@@ -77,7 +77,7 @@ def setup_autostart_flatpak(enable: bool = True):
         log.error(f"request_background failed")
         setup_autostart_desktop_entry(enable)
 
-def setup_autostart_desktop_entry(enable: bool = True):
+def setup_autostart_desktop_entry(enable: bool = True, native: bool = False):
     log.info("Setting up autostart using desktop entry")
 
 
@@ -88,7 +88,10 @@ def setup_autostart_desktop_entry(enable: bool = True):
     if enable:
         try:
             os.makedirs(os.path.dirname(AUTOSTART_DESKTOP_PATH), exist_ok=True)
-            shutil.copyfile(os.path.join("flatpak", "autostart.desktop"), AUTOSTART_DESKTOP_PATH)
+            if native:
+                shutil.copyfile(os.path.join("flatpak", "autostart-native.desktop"), AUTOSTART_DESKTOP_PATH)
+            else:
+                shutil.copyfile(os.path.join("flatpak", "autostart.desktop"), AUTOSTART_DESKTOP_PATH)
             log.info(f"Autostart set up at: {AUTOSTART_DESKTOP_PATH}")
         except Exception as e:
             log.error(f"Failed to set up autostart at: {AUTOSTART_DESKTOP_PATH} with error: {e}")

--- a/flatpak/autostart-native.desktop
+++ b/flatpak/autostart-native.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=StreamController
+Exec=streamcontroller -b


### PR DESCRIPTION
This PR attempts to fix autostart not working on non-flatpak installations.  
It does so by adding a `-native.desktop` file (slightly misleading in the flatpak subdirectory but I didn't find any other fitting place) which is used instead of the "normal" desktop entry when `is_flatpak() == False`.

I have tested this change on my non-flatpak Arch-based installation and on a flatpak Debian-based VM. Both chose the appropiate entry.

This fixes issue #214.  
Please let me know if I have made any oversight.