### PR TITLE
fix: Fix store thread crash on plugin uninstall & broken plugin update indicator

### DIFF
--- a/src/backend/PageManagement/Page.py
+++ b/src/backend/PageManagement/Page.py
@@ -316,7 +316,7 @@ class Page:
         for type in list(self.action_objects.keys()):
             for key in list(self.action_objects[type].keys()):
                 for state in list(self.action_objects[type][key].keys()):
-                    for index in list(self.action_objects[type][key].keys()):
+                    for index in list(self.action_objects[type][key][state].keys()):
                         if not isinstance(self.action_objects[type][key][state][index], ActionBase):
                             continue
                         if self.action_objects[type][key][state][index].plugin_base == plugin_obj:

--- a/src/backend/Store/StoreBackend.py
+++ b/src/backend/Store/StoreBackend.py
@@ -739,6 +739,9 @@ class StoreBackend:
         # FIXME: Check if not already added
         await self.subp_call(["git", "config", "--global", "--add", "safe.directory", os.path.abspath(local_path)])
 
+        # Run git pull to create .git/FETCH_HEAD. This allows us to check for available updates
+        await self.os_sys(f"cd '{local_path}' && git pull")
+
 
         ## Write version
         path = os.path.join(local_path, "VERSION")


### PR DESCRIPTION
This PR fixes a crash of the store thread when trying to check for actions which need to be removed when uninstalling a plugin.

The `isInstance` check failed because it tried to access an element out of bounds.  

This has been tested on a non-flatpak installation. The code now correctly removes actions for the uninstalled plugin and then removes the plugin directory.

I have not yet tested this for a flatpak installation (need to go real quick, will do later).

Edit: Same behavior on flatpak, fix confirmed to be working. However the actions of removed plugins are only removed after reoping the store another time, on a non-flatpak installation this is happening instantly. Not exactly sure why.