### PR TITLE
fix: Fix plugin installation scripts missing dependencies in venv

### DIFF
--- a/src/backend/Store/StoreBackend.py
+++ b/src/backend/Store/StoreBackend.py
@@ -762,14 +762,14 @@ class StoreBackend:
 
         response = await self.download_repo(repo_url=url, directory=local_path, commit_sha=plugin_data.commit_sha, branch_name=plugin_data.branch)
 
-        # Run install script if present
+        # Run install script if present. Make sure to use python binary used to run this process to not break venv dependency installations
         if os.path.isfile(os.path.join(local_path, "__install__.py")):
-            subprocess.run(f"python3 {os.path.join(local_path, '__install__.py')}", shell=True, start_new_session=True)
+            subprocess.run(f"{sys.executable} {os.path.join(local_path, '__install__.py')}", shell=True, start_new_session=True)
 
         # Install requirements from requirements.txt
         if os.path.isfile(os.path.join(local_path, "requirements.txt")):
-            subprocess.run(f"pip install -r {os.path.join(local_path, 'requirements.txt')}", shell=True, start_new_session=True)
-            
+            subprocess.run(f"{sys.executable} -m pip install -r {os.path.join(local_path, 'requirements.txt')}", shell=True, start_new_session=True)
+
         if response == 404:
             return 404
         


### PR DESCRIPTION
This PR fixes a bug where plugin `__install__.py` scripts always failed to execute when depending on modules not installed globally.

This was caused by the store using the global python binary instead of the one it was launched with itself.

Because of this bug, the OBS plugin for example was entirely unusable outside of global/flatpak installations.

This fixes the issue (can be closed after merging): https://github.com/StreamController/OBSPlugin/issues/10  
Issue was also mentioned in (this issue depends on other PRs): https://github.com/StreamController/StreamController/issues/214  
