### PR TITLE
BUGFIX: Active window not found

### DIFF
--- a/src/backend/WindowGrabber/Integrations/X11.py
+++ b/src/backend/WindowGrabber/Integrations/X11.py
@@ -96,6 +96,8 @@ class X11(Integration):
                 return
             stdout, stderr = root.communicate()
             window_ids = stdout.decode().strip().split("#")[1].strip().split(", ")
+            if len(window_ids) == 0:
+                return
             for window_id in window_ids:
                 if window_id == "0x0":
                     continue

--- a/src/backend/WindowGrabber/Integrations/X11.py
+++ b/src/backend/WindowGrabber/Integrations/X11.py
@@ -95,21 +95,21 @@ class X11(Integration):
             if root is None:
                 return
             stdout, stderr = root.communicate()
-            split = stdout.decode().strip().split()
-            if len(split) == 0:
-                return
-            window_id = split[-1]
+            window_ids = stdout.decode().strip().split("#")[1].strip().split(", ")
+            for window_id in window_ids:
+                if window_id == "0x0":
+                    continue
+                title = self.get_title(window_id)
+                class_name = self.get_class(window_id)
+
+                if None in [title, class_name]:
+                    return
+
+                return Window(class_name, title)
+
         except subprocess.CalledProcessError as e:
             log.error(f"An error occurred while running xprop: {e}")
             return
-
-        title = self.get_title(window_id)
-        class_name = self.get_class(window_id)
-
-        if None in [title, class_name]:
-            return
-
-        return Window(class_name, title)
 
     @log.catch
     def get_title(self, window_id: str) -> str:


### PR DESCRIPTION
In some cases xprop returns more window id's than just the active one.

Adopt `get_all_windows` approach to iterating over all the window id's and get the first one that is not `0x0`

Fixes https://github.com/StreamController/StreamController/issues/229