### PR TITLE
Fix loading of locales in certain cases

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,8 @@ from src.backend.Migration.Migrators.Migrator_1_5_0_beta_5 import Migrator_1_5_0
 # Import globals
 import globals as gl
 
+main_path = os.path.abspath(os.path.dirname(__file__))
+
 def write_logs(record):
     gl.logs.append(record)
 
@@ -98,7 +100,7 @@ def create_global_objects():
     gl.tray_icon = TrayIcon()
     # gl.tray_icon.run_detached()
 
-    gl.lm = LocaleManager(csv_path=os.path.join("locales", "locales.csv"))
+    gl.lm = LocaleManager(csv_path=os.path.join(main_path, "locales", "locales.csv"))
     gl.lm.set_to_os_default()
     gl.lm.set_fallback_language("en_US")
 


### PR DESCRIPTION
Change the locales path for loading to an absolute path (based on the main.py file) in order to allow launching the StreamController from any path. Currently we can only loads it with workdir being the source root of the project otherwise locales won’t be found and project will refuse to start.

May fix #225 