### PR TITLE
Fix threads

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -147,7 +147,7 @@ class App(Adw.Application):
         # Force quit if normal quit is not possible
         timer = threading.Timer(6, self.force_quit)
         timer.name = "force_quit_timer"
-        timer.setDaemon(True)
+        timer.daemon = True
         timer.start()
 
         for ctrl in gl.deck_manager.deck_controller:

--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -304,6 +304,7 @@ class MediaPlayerThread(threading.Thread):
             self.touchscreen_task.run()
             del self.touchscreen_task
             self.touchscreen_task = None
+
     def check_connection(self):
         try:
             self.deck_controller.deck.get_firmware_version()

--- a/src/backend/DeckManagement/Subclasses/ScreenSaver.py
+++ b/src/backend/DeckManagement/Subclasses/ScreenSaver.py
@@ -57,8 +57,8 @@ class ScreenSaver:
             self.timer.cancel()
         # *60 to go from minuts (how it is stored) to seconds (how the timer needs it)
         self.timer = threading.Timer(time_delay*60, self.on_timer_end)
-        self.timer.setDaemon(True)
-        self.timer.setName("ScreenSaverTimer")
+        self.timer.daemon = True
+        self.timer.name = "ScreenSaverTimer"
         if self.enable and not self.showing:
             self.timer.start()
 


### PR DESCRIPTION
Fixes colliding _close in the thread (that collide with Thread._close()) and make the application not closing properly.
Fix some deprecated method usages in threads (getName(), setName(), ... are replaced by properties)