### PR TITLE
KDE Application Switching: Wayland

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,9 @@ cython_debug/
 # VSCode
 .vscode/
 
+# PyCharm
+.idea/
+
 # own folders
 Assets/copyrighted/
 Assets/AssetManager/Assets/

--- a/src/app.py
+++ b/src/app.py
@@ -164,6 +164,9 @@ class App(Adw.Application):
             child.terminate()
 
         gl.tray_icon.stop()
+        
+        # Close the window grabber
+        gl.window_grabber.close_all()
 
         # Close all decks
         gl.deck_manager.close_all()

--- a/src/backend/WindowGrabber/Integration.py
+++ b/src/backend/WindowGrabber/Integration.py
@@ -29,3 +29,6 @@ class Integration:
     
     def get_active_window(self) -> Window:
         return None
+    
+    def close(self) -> None:
+        return None

--- a/src/backend/WindowGrabber/Integrations/Gnome.py
+++ b/src/backend/WindowGrabber/Integrations/Gnome.py
@@ -100,3 +100,6 @@ class Gnome(Integration):
     
     def get_is_connected(self) -> bool:
         return None not in (self.bus, self.proxy, self.interface)
+    
+    def close(self):
+        return

--- a/src/backend/WindowGrabber/Integrations/Hyprland.py
+++ b/src/backend/WindowGrabber/Integrations/Hyprland.py
@@ -84,6 +84,10 @@ class Hyprland(Integration):
 
         return None
     
+    def close(self):
+        return
+
+    
 class WatchForActiveWindowChange(threading.Thread):
     def __init__(self, hyprland: Hyprland):
         super().__init__(name="WatchForActiveWindowChange", daemon=True)

--- a/src/backend/WindowGrabber/Integrations/KDE.py
+++ b/src/backend/WindowGrabber/Integrations/KDE.py
@@ -107,6 +107,10 @@ class KDE(Integration):
     def get_is_connected(self) -> bool:
         return None not in (self.bus, self.proxy, self.interface)
 
+    def close(self) -> None:
+        if self.interface:
+            self.interface.stop()
+
     @staticmethod
     def script_name_to_window(s: str) -> Window:
         """converts a name from the KDE script into a Window class"""

--- a/src/backend/WindowGrabber/Integrations/KDE.py
+++ b/src/backend/WindowGrabber/Integrations/KDE.py
@@ -1,0 +1,172 @@
+"""
+Author: Core447
+Year: 2024
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+any later version.
+
+This programm comes with ABSOLUTELY NO WARRANTY!
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""
+import dbus
+from re import sub
+import threading
+import time
+import tempfile
+import os.path
+from datetime import datetime
+from src.backend.WindowGrabber.Integration import Integration
+from src.backend.WindowGrabber.Window import Window
+
+import subprocess
+import json
+from loguru import logger as log
+
+import globals as gl
+
+# Import typing
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from src.backend.WindowGrabber.WindowGrabber import WindowGrabber
+
+
+class KDE(Integration):
+    def __init__(self, window_grabber: "WindowGrabber"):
+        super().__init__(window_grabber=window_grabber)
+
+        self.bus: dbus.Bus = None
+        self.proxy = None
+        self.interface = None
+        self.tempScriptFile = None
+
+        self.allWindows = []
+        self.activeWindow = None
+        self.threadLock = threading.Lock()
+
+        self.start_active_window_change_thread()
+        self.connect_dbus_script()
+
+    def connect_dbus_script(self) -> None:
+        script = """
+                function onWindowActivated(win) {
+                        print("windowActive:" + win.resourceClass + ":" + win.resourceName);
+                }
+                function getAllWindows(win=null){
+                    const currentWindows = workspace.stackingOrder;
+                    var listAll = "";
+                    for(var i = 0;i < currentWindows.length; i++){
+                        listAll += currentWindows[i].resourceClass + ':' + currentWindows[i].resourceName + ',';
+                    }
+                    print("allWindows:" + listAll)
+                }
+                workspace.windowActivated.connect(onWindowActivated);
+                getAllWindows();
+                workspace.windowAdded.connect(getAllWindows);
+                workspace.windowRemoved.connect(getAllWindows);
+            """
+        tempDir = tempfile.gettempdir()
+        self.tempScriptFile = os.path.join(tempDir, 'streamControllerKdeScript.js')
+        with open(self.tempScriptFile, 'w') as f:
+            f.write(script)
+
+        try:
+            self.bus = dbus.SessionBus()
+            # temporary proxy for putting the script in KDE
+            proxy = self.bus.get_object("org.kde.KWin", "/Scripting")
+            interface = dbus.Interface(proxy, "org.kde.kwin.Scripting")
+            # first check if the script already is running, if so don't start another one
+            if interface.isScriptLoaded(self.tempScriptFile):
+                log.debug('KDE script already running')
+                return
+            scriptId = interface.loadScript(self.tempScriptFile)
+
+            self.proxy = self.bus.get_object("org.kde.KWin", f"/Scripting/Script{scriptId}")
+            self.interface = dbus.Interface(self.proxy, "org.kde.kwin.Script")
+            self.interface.run()
+        except dbus.exceptions.DBusException as e:
+            log.error(f"Failed to connect to D-Bus: {e}")
+            pass
+
+    @log.catch
+    def start_active_window_change_thread(self):
+        self.active_window_change_thread = WatchForScriptLogs(self)
+        self.active_window_change_thread.start()
+
+    def get_all_windows(self) -> list[Window]:
+        with self.threadLock:
+            return self.allWindows
+
+    def get_active_window(self) -> Window:
+        with self.threadLock:
+            return self.activeWindow
+
+    def get_is_connected(self) -> bool:
+        return None not in (self.bus, self.proxy, self.interface)
+
+    @staticmethod
+    def script_name_to_window(s: str) -> Window:
+        """converts a name from the KDE script into a Window class"""
+        s = s.split(':')
+        return Window(wm_class=s[0], title=s[1])
+
+
+class WatchForScriptLogs(threading.Thread):
+    """Thread that reads all windows and the active window from systemd, printed by the script ran"""
+    def __init__(self, kde: KDE):
+        super().__init__(name="WatchForActiveWindowChange", daemon=True)
+        self.kde = kde
+
+        self.last_active_window = kde.get_active_window()
+        self.lastCheck = datetime.now()
+
+    @log.catch
+    def run(self) -> None:
+        while gl.threads_running:
+            time.sleep(0.2)
+
+            new_active_window = None
+
+            msg_all = subprocess.run("journalctl QT_CATEGORY=js QT_CATEGORY=kwin_scripting -o cat --since \"" + str(self.lastCheck) + "\"",
+                                     capture_output=True, shell=True)
+            msg_all = msg_all.stdout.decode().rstrip().split("\n")
+
+            self.lastCheck = datetime.now()
+
+            for msg in msg_all:
+                if msg == '':
+                    continue
+                msg = msg.lstrip("js: ")
+                # if we get a allWindows message, then update the current windows
+                if msg.startswith("allWindows:"):
+                    msg = msg.replace("allWindows:", "")
+                    msg = msg.split(',')
+                    with self.kde.threadLock:
+                        self.kde.allWindows = []
+                        for wind in msg:
+                            if wind == '':
+                                continue
+                            wind = self.kde.script_name_to_window(wind)
+                            self.kde.allWindows.append(wind)
+
+                # otherwise update the current active window
+                elif msg.startswith("windowActive:"):
+                    msg = msg.replace("windowActive:", "")
+                    new_active_window = msg
+
+            # if we don't have a window to update, continue
+            if new_active_window is None:
+                continue
+            new_active_window = self.kde.script_name_to_window(new_active_window)
+
+            if new_active_window == self.last_active_window:
+                continue
+
+            self.last_active_window = new_active_window
+
+            with self.kde.threadLock:
+                self.kde.activeWindow = new_active_window
+            self.kde.window_grabber.on_active_window_changed(new_active_window)

--- a/src/backend/WindowGrabber/Integrations/Sway.py
+++ b/src/backend/WindowGrabber/Integrations/Sway.py
@@ -58,6 +58,9 @@ class Sway(Integration):
             if not client["focused"]:
                 continue
             return self._parse_window(client)
+    
+    def close(self) -> None:
+        return
 
     def _get_windows(self) -> list[dict[str, Any]]:
         windows = []

--- a/src/backend/WindowGrabber/Integrations/X11.py
+++ b/src/backend/WindowGrabber/Integrations/X11.py
@@ -87,6 +87,9 @@ class X11(Integration):
             windows.append(Window(class_name, title))
 
         return windows
+    
+    def close(self) -> None:
+        return
 
     @log.catch
     def get_active_window(self) -> Window:

--- a/src/backend/WindowGrabber/WindowGrabber.py
+++ b/src/backend/WindowGrabber/WindowGrabber.py
@@ -72,6 +72,10 @@ class WindowGrabber:
             self.integration = KDE(self)
         elif self.server == "x11":
             self.integration = X11(self)
+    
+    def close_all(self) -> None:
+        log.info(f"Closing window grabber")
+        self.integration.close()
 
     @log.catch
     def get_all_windows(self) -> list[Window]:

--- a/src/backend/WindowGrabber/WindowGrabber.py
+++ b/src/backend/WindowGrabber/WindowGrabber.py
@@ -29,10 +29,11 @@ from src.backend.WindowGrabber.Integrations.Hyprland import Hyprland
 from src.backend.WindowGrabber.Integrations.Gnome import Gnome
 from src.backend.WindowGrabber.Integrations.Sway import Sway
 from src.backend.WindowGrabber.Integrations.X11 import X11
+from src.backend.WindowGrabber.Integrations.KDE import KDE
 
 class WindowGrabber:
     def __init__(self):
-        self.SUPPORTED_ENVS = ["hyprland", "gnome", "sway", "x11"]
+        self.SUPPORTED_ENVS = ["hyprland", "gnome", "sway", "x11", "kde", "wayland"]
 
         self.integration: Integration = None
         self.init_integration()
@@ -67,6 +68,8 @@ class WindowGrabber:
             self.integration = Gnome(self)
         elif self.environment == "sway":
             self.integration = Sway(self)
+        elif self.environment == 'kde':
+            self.integration = KDE(self)
         elif self.server == "x11":
             self.integration = X11(self)
 
@@ -139,7 +142,6 @@ class WindowGrabber:
                     return
                 if not deck_controller.deck.is_open():
                     return
-                
 
                 if deck_controller.page_auto_loaded:
                     active_page_change_info = gl.page_manager.auto_change_info.get(os.path.abspath(deck_controller.active_page.json_path))


### PR DESCRIPTION
This PR adds native KDE support for window/app switching, which is mostly because of Wayland. But it should also work on X11 with KDE

TODO:
- [x] Add a closing handler to stop the KDE script
- [ ] Make sure works with Flatpack