### PR TITLE
Add Stream Deck NEO to udev.rules

### DIFF
--- a/udev.rules
+++ b/udev.rules
@@ -7,3 +7,4 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="008f", TAG+="uacce
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0080", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0084", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0086", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="009a", TAG+="uaccess"


### PR DESCRIPTION
Hi, nixpkgs StreamController package maintainer here. We packaged `1.5.0-beta7`, although changlog says Stream Deck Neo support is added, udev rule seems to be missing (we install this `udev.rules` file into user's system)

Thanks for the awesome project!