### PR TITLE
Fix(ActionConfigurator): UI not getting hidden properly

### DIFF
--- a/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
+++ b/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
@@ -157,10 +157,13 @@ class ConfigGroup(Adw.PreferencesGroup):
         pass
 
     def load_for_action(self, action: ActionBase):
-        if not hasattr(action, "get_config_rows"):
+        base_method = getattr(ActionBase, "get_config_rows", None)
+        action_method = getattr(action.__class__, "get_config_rows", None)
+
+        if base_method == action_method:
             self.hide()
             return
-        
+
         config_rows = action.get_config_rows()
         if config_rows is None:
             self.hide()
@@ -190,13 +193,18 @@ class CustomConfigs(Gtk.Box):
         super().__init__(orientation=Gtk.Orientation.VERTICAL, **kwargs)
         self.parent = parent
 
-        self.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL, margin_bottom=6))
+        self.seperator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL, margin_bottom=6)
+
+        self.append(self.seperator)
 
         self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, hexpand=True)
         self.append(self.main_box)
 
     def load_for_action(self, action):
-        if not hasattr(action, "get_custom_config_area"):
+        base_method = getattr(ActionBase, "get_custom_config_area", None)
+        action_method = getattr(action.__class__, "get_custom_config_area", None)
+
+        if base_method == action_method:
             self.hide()
             return
         

--- a/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
+++ b/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
@@ -81,11 +81,6 @@ class ActionConfigurator(Gtk.Box):
         self.comment_group.load_for_action(action, index)
         self.event_assigner.load_for_action(action)
 
-        if not self.config_group.is_visible():
-            self.custom_configs.seperator.hide()
-        else:
-            self.custom_configs.seperator.show()
-
     def on_back_button_click(self, button):
         self.sidebar.main_stack.set_visible_child_name("configurator_stack")
 
@@ -207,6 +202,9 @@ class CustomConfigs(Gtk.Box):
         if custom_config_area is None:
             self.hide()
             return
+
+        if not action.get_config_rows():
+            self.seperator.hide()
         
         # Clear
         self.clear()

--- a/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
+++ b/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
@@ -67,12 +67,14 @@ class ActionConfigurator(Gtk.Box):
         self.config_group = ConfigGroup(self)
         self.main_box.append(self.config_group)
 
+        self.config_group_and_custom_configs_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL, margin_top=20, margin_bottom=20)
+        self.main_box.append(self.config_group_and_custom_configs_separator)
+
         self.custom_configs = CustomConfigs(self, margin_top=6)
         self.main_box.append(self.custom_configs)
 
         self.remove_button = RemoveButton(self, margin_top=12)
         self.main_box.append(self.remove_button)
-
 
     def load_for_action(self, action, index):
         self.config_group.load_for_action(action)
@@ -80,6 +82,8 @@ class ActionConfigurator(Gtk.Box):
         self.remove_button.load_for_action(action, index)
         self.comment_group.load_for_action(action, index)
         self.event_assigner.load_for_action(action)
+
+        self.config_group_and_custom_configs_separator.set_visible(self.config_group.is_visible() and self.custom_configs.is_visible())
 
     def on_back_button_click(self, button):
         self.sidebar.main_stack.set_visible_child_name("configurator_stack")
@@ -188,10 +192,6 @@ class CustomConfigs(Gtk.Box):
         super().__init__(orientation=Gtk.Orientation.VERTICAL, **kwargs)
         self.parent = parent
 
-        self.seperator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL, margin_bottom=6)
-
-        self.append(self.seperator)
-
         self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, hexpand=True)
         self.append(self.main_box)
 
@@ -203,14 +203,11 @@ class CustomConfigs(Gtk.Box):
             self.hide()
             return
 
-        if not action.get_config_rows():
-            self.seperator.hide()
-        
         # Clear
         self.clear()
 
-        if custom_config_area is not None:
-            self.main_box.append(custom_config_area)
+        # Append custom content
+        self.main_box.append(custom_config_area)
 
         # Show
         self.show()

--- a/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
+++ b/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
@@ -81,6 +81,11 @@ class ActionConfigurator(Gtk.Box):
         self.comment_group.load_for_action(action, index)
         self.event_assigner.load_for_action(action)
 
+        if not self.config_group.is_visible():
+            self.custom_configs.seperator.hide()
+        else:
+            self.custom_configs.seperator.show()
+
     def on_back_button_click(self, button):
         self.sidebar.main_stack.set_visible_child_name("configurator_stack")
 

--- a/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
+++ b/src/windows/mainWindow/elements/Sidebar/elements/ActionConfigurator.py
@@ -162,17 +162,12 @@ class ConfigGroup(Adw.PreferencesGroup):
         pass
 
     def load_for_action(self, action: ActionBase):
-        base_method = getattr(ActionBase, "get_config_rows", None)
-        action_method = getattr(action.__class__, "get_config_rows", None)
-
-        if base_method == action_method:
-            self.hide()
-            return
-
         config_rows = action.get_config_rows()
-        if config_rows is None:
+
+        if not config_rows:
             self.hide()
             return
+
         # Load labels
         self.set_title(action.action_name)
         self.set_description(action.plugin_base.plugin_name)
@@ -206,13 +201,6 @@ class CustomConfigs(Gtk.Box):
         self.append(self.main_box)
 
     def load_for_action(self, action):
-        base_method = getattr(ActionBase, "get_custom_config_area", None)
-        action_method = getattr(action.__class__, "get_custom_config_area", None)
-
-        if base_method == action_method:
-            self.hide()
-            return
-        
         # Append custom config area
         custom_config_area = action.get_custom_config_area()
         


### PR DESCRIPTION
The Rows or Custom Config were not hidden properly when the methods were not present in the Action.
Changed it so we compare the actual method and hide if the method is the same, meaning it was not overridden.
Also made the 2nd separator hide as this would not look nice without it