### PR TITLE
Using --change-page argument no longer pops up main window

### DIFF
--- a/main.py
+++ b/main.py
@@ -220,7 +220,7 @@ def quit_running():
 
 def make_api_calls():
     if not gl.argparser.parse_args().change_page:
-        return
+        return False
     
     session_bus = dbus.SessionBus()
     obj: dbus.BusObject = None
@@ -239,11 +239,17 @@ def make_api_calls():
         else:
             # Other instance is running - call dbus interfaces
             action_interface.Activate("change_page", [[serial_number, page_name]], [])
+            return True
+
+    return False
 
 
     
 @log.catch
 def main():
+    if make_api_calls():
+        return
+
     gsk_render_env_var = os.environ.get("GSK_RENDERER")
     if gsk_render_env_var != "ngl":
         log.warning('Should you get an Error 71 (Protocol error) please add '
@@ -251,7 +257,6 @@ def main():
 
     DBusGMainLoop(set_as_default=True)
     # Dbus
-    make_api_calls()
     quit_running()
 
     reset_all_decks()


### PR DESCRIPTION
A simple change to the startup order, allows --change-page to affect running instances without opening the main interface.