### PR TITLE
Update udev.rules

### DIFF
--- a/udev.rules
+++ b/udev.rules
@@ -8,3 +8,4 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0080", TAG+="uacce
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0084", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0086", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="009a", TAG+="uaccess"
+KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uaccess", GROUP="input", MODE="0660"


### PR DESCRIPTION
I got a permission error for /dev/uinput on PoPOS!. I have fixed this by adding an additional rule to the udev-rules file which allows access to the device. After a reboot, my installation now works.