### PR TITLE
Feat(EventHolder): Added suffix to EventHolders

### DIFF
--- a/src/backend/PluginManager/EventHolder.py
+++ b/src/backend/PluginManager/EventHolder.py
@@ -5,12 +5,14 @@ class EventHolder:
     """
         Holder for Event Callbacks for the specified Event ID
     """
-    def __init__(self, plugin_base: "PluginBase", event_id: str):
-        if event_id in ["", None]:
-            raise ValueError("Please specify an signal id")
+    def __init__(self, plugin_base: "PluginBase",
+                 event_id: str = None,
+                 event_id_suffix: str = None):
+        if event_id in ["", None] and event_id_suffix in ["", None]:
+            raise ValueError("Please specify a signal id")
 
         self.plugin_base = plugin_base
-        self.event_id = event_id
+        self.event_id = event_id or f"{self.plugin_base.get_plugin_id()}::{event_id_suffix}"
         self.observers: list = []
 
     def add_listener(self, callback: callable):

--- a/src/backend/PluginManager/PluginBase.py
+++ b/src/backend/PluginManager/PluginBase.py
@@ -292,7 +292,7 @@ class PluginBase(rpyc.Service):
     def add_action_holder_groups(self, action_holder_groups: list[ActionHolderGroup]) -> None:
         self.action_holder_groups.update(action_holder_groups)
 
-    def connect_to_event(self, event_id: str, callback: callable) -> None:
+    def connect_to_event(self, callback: callable, event_id: str = None, event_id_suffix: str = None) -> None:
         """
         Connects a Callback to the Event which gets specified by the event ID
 
@@ -303,7 +303,9 @@ class PluginBase(rpyc.Service):
         Returns:
             None
         """
-        if event_id in self.event_holders:
+        full_id = event_id or f"{self.get_plugin_id()}::{event_id_suffix}"
+
+        if full_id in self.event_holders:
             self.event_holders[event_id].add_listener(callback)
         else:
             log.warning(f"{event_id} does not exist in {self.plugin_name}")


### PR DESCRIPTION
EventHolders can now use a suffix aswell just as ActionHolders

This got also added for the `connect_to_event` method as this is the method to use inside the plugin itself
`connect_to_event_directly` does not have this added as you have to pass in the `plugin_id` and `event_id` separately