### PR TITLE
fix(rpyc)(#329): add config to fe->be connection

### DIFF
--- a/src/backend/PluginManager/PluginBase.py
+++ b/src/backend/PluginManager/PluginBase.py
@@ -555,7 +555,7 @@ class PluginBase(rpyc.Service):
         Returns:
             None
         """
-        self.backend_connection = rpyc.connect("localhost", port)
+        self.backend_connection = rpyc.connect("localhost", port, config={"allow_public_attrs": True})
         self.backend = self.backend_connection.root
         gl.plugin_manager.backends.append(self.backend_connection)
 


### PR DESCRIPTION
* Adds config to frontend-to-backend connection with same semantics as the frontend server in PluginBase.
* A separate change (in streamcontroller-plugin-tools) is required to remediate an identical issue in BackendBase (though impact from that omission was not observed as part of this defect).
* This change is not intended to change data accessibility beyond what is semantically expected, and as such does not add further affordances like `set_attr` (which would allow property setters) or other useful RPyC permissions.

## Testing

* Pulled `https://github.com/Kekemui/VeadoSC`/`6a-nonfunctional` as a custom plugin and verified cross-process data access functioned as expected.
  * (Note there are typing issues that inhibit further functionality of the plugin [specifically w.r.t. netrefs obscuring event types]. Full functionality of the plugin is neither expected nor required for validation of this PR, just that the plugin spins up.)