### PR TITLE
[improvement] only return usb devices made by elgato

### DIFF
--- a/main.py
+++ b/main.py
@@ -169,11 +169,11 @@ def update_assets():
 @log.catch
 def reset_all_decks():
     # Find all USB devices
-    devices = usb.core.find(find_all=True)
+    devices = usb.core.find(find_all=True, idVendor=DeviceManager.USB_VID_ELGATO)
     for device in devices:
         try:
             # Check if it's a StreamDeck
-            if device.idVendor == DeviceManager.USB_VID_ELGATO and device.idProduct in [
+            if device.idProduct in [
                 DeviceManager.USB_PID_STREAMDECK_ORIGINAL,
                 DeviceManager.USB_PID_STREAMDECK_ORIGINAL_V2,
                 DeviceManager.USB_PID_STREAMDECK_MINI,


### PR DESCRIPTION
if a pc has a lot of usb devices attached the query for all of them was very slow.

we can filter it by only listing devices made by elgato and then check the (hopefully smaller) list for the actual products.

this sped up the initialization from a few mins to 2.5 seconds on my pc.