### PR TITLE
Refactor(GenerativeUI): Some smaller changes

### DIFF
--- a/GtkHelper/GenerativeUI/GenerativeUI.py
+++ b/GtkHelper/GenerativeUI/GenerativeUI.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TypeVar, Generic
+from typing import TypeVar, Callable
 
 import gi
 from gi.repository import Gtk
@@ -10,17 +10,17 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
-class GenerativeUI(ABC, Generic[T]):
-    action_base: "ActionBase"
-    var_name: str
-    default_value: T
-    on_change: callable
-    widget: Gtk.Widget
+class GenerativeUI[T](ABC):
+    _action_base: "ActionBase"
+    _var_name: str # name of the key in the actions settings
+    _default_value: T # default value of the key
+    on_change: Callable[[T], None] # method that gets called when the value changes
+    widget: Gtk.Widget # The actual widget of the UI Element
 
-    def __init__(self, action_base: "ActionBase", var_name: str, default_value: T, on_change: callable = None):
-        self.action_base = action_base
-        self.var_name = var_name
-        self.default_value = default_value
+    def __init__(self, action_base: "ActionBase", var_name: str, default_value: T, on_change: Callable[[T], None] = None):
+        self._action_base = action_base
+        self._var_name = var_name
+        self._default_value = default_value
         self.on_change = on_change
         self.widget: Gtk.Widget = None
 
@@ -31,27 +31,41 @@ class GenerativeUI(ABC, Generic[T]):
     @abstractmethod
     def set_ui_value(self, value: T):
         pass
-
-    def get_value(self) -> T:
-        return self.get_key(self.var_name, self.default_value)
     
     def _handle_value_changed(self, new_value: T):
-        self.set_key(self.var_name, new_value)
+        self.set_value(new_value)
         
         if self.on_change:
             self.on_change(new_value)
 
-    def load_value(self):
-        self.set_ui_value(self.get_key(self.var_name))
+    def load_value_into_ui(self):
+        value = self.get_value()
+        self.set_ui_value(value)
 
-    def set_key(self, key: str, value: T):
-        settings = self.action_base.get_settings()
-        settings[key] = value
-        self.action_base.set_settings(settings)
+    def reset_value(self):
+        self.set_value()
+        self.load_value_into_ui()
 
-    def get_key(self, key: str, fallback: T) -> T:
-        settings = self.action_base.get_settings()
-        return settings.get(key, fallback)
+    def set_value(self, value: T):
+        """
+        Sets the settings with the given value
+        """
+        settings = self._action_base.get_settings()
+
+        settings[self._var_name] = value
+        self._action_base.set_settings(settings)
+
+    def get_value(self, fallback: T = None) -> T:
+        """
+        Returns the value from the settings
+        """
+        settings = self._action_base.get_settings()
+
+        if fallback is None:
+            fallback = self._default_value
+
+        return settings.get(self._var_name, fallback)
 
     def load_initial_ui_value(self):
-        self.set_ui_value(self.get_value())
+        value = self.get_value()
+        self.set_ui_value(value)


### PR DESCRIPTION
- Made some values private as they normally shouldnt be changed after setting, this just makes it clear
- Using a more up to date standard for defining the generic in the class
- Renamed some methods as `*_key()` doesnt make sense because were setting the value, not the key
- `on_change` now expects a method with the exact signature that is defined in the class, providing better type hinting