### PR TITLE
Feat(GenerativeUI): Added translation method

### DIFF
--- a/GtkHelper/GenerativeUI/GenerativeUI.py
+++ b/GtkHelper/GenerativeUI/GenerativeUI.py
@@ -69,3 +69,9 @@ class GenerativeUI[T](ABC):
     def load_initial_ui_value(self):
         value = self.get_value()
         self.set_ui_value(value)
+
+    def get_translation(self, key: str, fallback: str):
+        if key is None or fallback is None:
+            return ""
+
+        return self._action_base.get_translation(key, fallback)


### PR DESCRIPTION
This Implements a simple method that returns the translated text given a string.

To auto translate titles or subtitles a simple `get_translation` call can be made

In here we pass the title as the key and as the fallback, meaning it tries to auto translates the title and uses the title as a fallback if nothing was found. 
```py
self.widget: Adw.SwitchRow = Adw.SwitchRow(
    title=self.get_translation(title, title),
    subtitle=self.get_translation(subtitle, subtitle),
    active=default_value
)
```