### PR TITLE
chore(deprecations)(beta.9): add @deprecation warnings to deprecated plugin-facing classes

### DIFF
--- a/GtkHelper/GtkHelper.py
+++ b/GtkHelper/GtkHelper.py
@@ -446,7 +446,7 @@ class LoadingScreen(Gtk.Box):
             GLib.idle_add(self.spinner.stop)
 
 
-@deprecated("This has been deprecated in favor of the ComboRow implementation at GtkHelper.ComboRow.ComboRow. It will be removed in 1.5.0-beta.10")
+@deprecated("This has been deprecated in favor of GtkHelper.ComboRow.ComboRow.")
 class ComboRow(Adw.PreferencesRow):
     def __init__(self, title, model: Gtk.ListStore, **kwargs):
         super().__init__(title=title, **kwargs)
@@ -464,7 +464,7 @@ class ComboRow(Adw.PreferencesRow):
         self.main_box.append(self.combo_box)
 
 
-@deprecated("This will be removed in 1.5.0-beta.10")
+@deprecated("This has been deprecated in favor of GtkHelper.ScaleRow.ScaleRow.")
 class ScaleRow(Adw.PreferencesRow):
     def __init__(self, title, value: float, min: float, max: float, step: float, text_right: str = "", text_left: str = "", **kwargs):
         super().__init__(title=title, **kwargs)

--- a/GtkHelper/GtkHelper.py
+++ b/GtkHelper/GtkHelper.py
@@ -12,6 +12,8 @@ This programm comes with ABSOLUTELY NO WARRANTY!
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+from warnings import deprecated
+
 # Import gtk modules
 import gi
 
@@ -81,7 +83,7 @@ class BetterExpander(Adw.ExpanderRow):
         revealer_list_box = self.get_list_box()
         if revealer_list_box is None:
             return
-        
+
         rows = []
         child = revealer_list_box.get_first_child()
         while child is not None:
@@ -94,16 +96,16 @@ class BetterExpander(Adw.ExpanderRow):
         expander_box = self.get_first_child()
         if expander_box is None:
             return
-        
+
         expander_list_box = expander_box.get_first_child()
         if expander_list_box is None:
             return
-        
+
         revealer = expander_list_box.get_next_sibling()
         revealer_list_box = revealer.get_first_child()
 
         return revealer_list_box
-        
+
     def clear(self):
         rows = self.get_rows()
         list_box = self.get_list_box()
@@ -120,7 +122,7 @@ class BetterExpander(Adw.ExpanderRow):
         if after_index is None:
             log.warning("After child could not be found. Please add it first")
             return
-        
+
         # Remove child from list
         childs.remove(child)
 
@@ -141,9 +143,9 @@ class BetterExpander(Adw.ExpanderRow):
         for i, action in enumerate(self.actions):
             if action == child:
                 return i
-        
+
         raise ValueError("Child not found")
-    
+
     def get_arrow_image(self) -> Gtk.Image:
         box: Gtk.Box = self.get_child()
         list_box: Gtk.ListBox = box.get_first_child()
@@ -184,7 +186,7 @@ class BetterPreferencesGroup(Adw.PreferencesGroup):
         list_box = self.get_list_box()
         if list_box is None:
             return
-        
+
         rows = []
         child = list_box.get_first_child()
         while child is not None:
@@ -200,7 +202,7 @@ class BetterPreferencesGroup(Adw.PreferencesGroup):
         list_box = third_box.get_first_child()
 
         return list_box
-    
+
 class AttributeRow(Adw.PreferencesRow):
     def __init__(self, title:str, attr:str, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -226,7 +228,7 @@ class AttributeRow(Adw.PreferencesRow):
         if attr is None:
             attr = "N/A"
         self.attribute_label.set_label(attr)
-        
+
 class EntryDialog(Gtk.ApplicationWindow):
     def __init__(self, parent_window, dialog_title:str, entry_heading:str = "Name:", default_text:str = None, confirm_label:str = "OK", forbid_answers:list[str] = [],
                  empty_warning:str = "The name cannot be empty", cancel_label:str = "Cancel", already_exists_warning:str = "This name already exists",
@@ -279,7 +281,7 @@ class EntryDialog(Gtk.ApplicationWindow):
 
     def on_cancel(self, button):
         self.destroy()
-    
+
 
     def on_name_change(self, entry):
         if entry.get_text() == '':
@@ -335,7 +337,7 @@ class ErrorPage(Gtk.Box):
         super().__init__(orientation=Gtk.Orientation.VERTICAL,
                          halign=Gtk.Align.CENTER,
                          valign=Gtk.Align.CENTER)
-        
+
         self.reload_func = reload_func
         self.error_text = error_text
         self.reload_args = reload_args
@@ -347,7 +349,7 @@ class ErrorPage(Gtk.Box):
 
         self.retry_button = Gtk.Button(label="Retry")
         self.retry_button.connect("clicked", self.on_retry_button_click)
-        
+
         if callable(self.reload_func):
             self.append(self.retry_button)
 
@@ -427,7 +429,7 @@ class LoadingScreen(Gtk.Box):
     def __init__(self):
         super().__init__(orientation=Gtk.Orientation.VERTICAL, hexpand=True, vexpand=True,
                          valign=Gtk.Align.CENTER, halign=Gtk.Align.CENTER)
-        
+
         self.spinner = Gtk.Spinner(spinning=False)
         self.append(self.spinner)
 
@@ -444,6 +446,7 @@ class LoadingScreen(Gtk.Box):
             GLib.idle_add(self.spinner.stop)
 
 
+@deprecated("This has been deprecated in favor of the ComboRow implementation at GtkHelper.ComboRow.ComboRow. It will be removed in 1.5.0-beta.10")
 class ComboRow(Adw.PreferencesRow):
     def __init__(self, title, model: Gtk.ListStore, **kwargs):
         super().__init__(title=title, **kwargs)
@@ -461,6 +464,7 @@ class ComboRow(Adw.PreferencesRow):
         self.main_box.append(self.combo_box)
 
 
+@deprecated("This will be removed in 1.5.0-beta.10")
 class ScaleRow(Adw.PreferencesRow):
     def __init__(self, title, value: float, min: float, max: float, step: float, text_right: str = "", text_left: str = "", **kwargs):
         super().__init__(title=title, **kwargs)

--- a/GtkHelper/ItemListComboRow.py
+++ b/GtkHelper/ItemListComboRow.py
@@ -11,6 +11,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
 from typing import Sequence
+from warnings import deprecated
 
 import gi
 gi.require_version("Gtk", "4.0")
@@ -20,7 +21,7 @@ from gi.repository import Gtk, Adw, Gio, GObject
 from loguru import logger as log
 
 
-@deprecated("This will be removed in 1.5.0-beta.10")
+@deprecated("This has been deprecated in favor of GtkHelper.ComboRow")
 class ItemListComboRowListItem(GObject.Object):
     def __init__(self, key: str, name: str):
         super().__init__()
@@ -36,7 +37,7 @@ class ItemListComboRowListItem(GObject.Object):
         return self._name
 
 
-@deprecated("This will be removed in 1.5.0-beta.10")
+@deprecated("This has been deprecated in favor of GtkHelper.ComboRow")
 class ItemListComboRow(Adw.ComboRow):
     """
     A primitive wrapper, to make simple "combo box"-style selections.

--- a/GtkHelper/ItemListComboRow.py
+++ b/GtkHelper/ItemListComboRow.py
@@ -20,6 +20,7 @@ from gi.repository import Gtk, Adw, Gio, GObject
 from loguru import logger as log
 
 
+@deprecated("This will be removed in 1.5.0-beta.10")
 class ItemListComboRowListItem(GObject.Object):
     def __init__(self, key: str, name: str):
         super().__init__()
@@ -35,6 +36,7 @@ class ItemListComboRowListItem(GObject.Object):
         return self._name
 
 
+@deprecated("This will be removed in 1.5.0-beta.10")
 class ItemListComboRow(Adw.ComboRow):
     """
     A primitive wrapper, to make simple "combo box"-style selections.

--- a/GtkHelper/SearchComboRow.py
+++ b/GtkHelper/SearchComboRow.py
@@ -14,6 +14,7 @@ from gi.repository import Gtk, Adw, Gio, GObject
 
 from loguru import logger as log
 
+@deprecated("This will be removed in 1.5.0-beta.10")
 class SearchComboRowItem(GObject.Object):
     __gtype_name__ = 'SearchComboRowItem'
 
@@ -25,6 +26,7 @@ class SearchComboRowItem(GObject.Object):
     def display_label(self):
         return self._display_label
 
+@deprecated("This will be removed in 1.5.0-beta.10")
 class SearchComboRow(Adw.PreferencesRow):
     __gtype_name__ = "SearchComboRow"
     __gsignals__ = {

--- a/GtkHelper/SearchComboRow.py
+++ b/GtkHelper/SearchComboRow.py
@@ -6,6 +6,7 @@ Modified by: G4PLS
 Modified the Original code to fit the purpose of this application.
 """
 
+from warnings import deprecated
 import gi
 
 gi.require_version("Gtk", "4.0")
@@ -14,7 +15,7 @@ from gi.repository import Gtk, Adw, Gio, GObject
 
 from loguru import logger as log
 
-@deprecated("This will be removed in 1.5.0-beta.10")
+@deprecated("This has been deprecated in favor of GtkHelper.ComboRow")
 class SearchComboRowItem(GObject.Object):
     __gtype_name__ = 'SearchComboRowItem'
 
@@ -26,7 +27,7 @@ class SearchComboRowItem(GObject.Object):
     def display_label(self):
         return self._display_label
 
-@deprecated("This will be removed in 1.5.0-beta.10")
+@deprecated("This has been deprecated in favor of GtkHelper.ComboRow")
 class SearchComboRow(Adw.PreferencesRow):
     __gtype_name__ = "SearchComboRow"
     __gsignals__ = {

--- a/src/backend/PluginManager/ActionBase.py
+++ b/src/backend/PluginManager/ActionBase.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from src.backend.PageManagement.Page import Page
     from src.backend.PluginManager.PluginBase import PluginBase
 
-@deprecated("This has been deprecated in favor of ActionCore. It may be removed in beta.10.")
+@deprecated("This has been deprecated in favor of ActionCore.")
 class ActionBase(ActionCore):
     def __init__(self, action_id: str, action_name: str,
                  deck_controller: "DeckController", page: "Page", plugin_base: "PluginBase", state: int,

--- a/src/backend/PluginManager/ActionBase.py
+++ b/src/backend/PluginManager/ActionBase.py
@@ -1,3 +1,5 @@
+from warnings import deprecated
+
 from src.backend.PluginManager.EventAssigner import EventAssigner
 from src.backend.DeckManagement.InputIdentifier import Input, InputEvent
 from src.backend.PluginManager.ActionCore import ActionCore
@@ -9,6 +11,7 @@ if TYPE_CHECKING:
     from src.backend.PageManagement.Page import Page
     from src.backend.PluginManager.PluginBase import PluginBase
 
+@deprecated("This has been deprecated in favor of ActionCore. It may be removed in beta.10.")
 class ActionBase(ActionCore):
     def __init__(self, action_id: str, action_name: str,
                  deck_controller: "DeckController", page: "Page", plugin_base: "PluginBase", state: int,
@@ -118,7 +121,7 @@ class ActionBase(ActionCore):
             callback=lambda data: self.event_callback(Input.Touchscreen.Events.DRAG_RIGHT, data)
         ))
 
-            
+
 
     # backward compatibility
     def event_callback(self, event: InputEvent, data: dict = None):


### PR DESCRIPTION
* Adds deprecation warnings to GtkHelper classes slated for removal in beta.10, based on https://github.com/StreamController/StreamController/commit/ad68f827f39610e7ea8c09def8b70ca03c1cdf82
* Adds a deprecation warning to ActionBase, based on comments by GAPLS in dev chat Discord.

## Testing

* None - did not want to revert libadwaita-1.7.0 and accidentally push that back upstream.
