### PR TITLE
feat: lock screen support for Hyprland

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,7 @@ from src.Signals.SignalManager import SignalManager
 from src.backend.WindowGrabber.WindowGrabber import WindowGrabber
 from src.backend.GnomeExtensions import GnomeExtensions
 from src.backend.PermissionManagement.FlatpakPermissionManager import FlatpakPermissionManager
+from src.backend.Wayland.Wayland import Wayland
 from src.backend.LockScreenManager.LockScreenManager import LockScreenManager
 from src.tray import TrayIcon
 from src.backend.Logger import Logger, LoggerConfig, Loglevel
@@ -155,6 +156,10 @@ def create_global_objects():
     gl.plugin_manager.generate_action_index()
 
     gl.window_grabber = WindowGrabber()
+
+    if os.getenv("WAYLAND_DISPLAY", False):
+        gl.wayland = Wayland()
+
     gl.lock_screen_detector = LockScreenManager()
 
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,6 +75,7 @@ pyproject-metadata==0.9.0
 Pyro5==5.15
 pyspellchecker==0.8.2
 python-dateutil==2.9.0.post0
+python-wayland-extra==0.7.0
 pyudev==0.24.3
 pyusb==1.3.1
 PyYAML==6.0.2
@@ -105,3 +106,4 @@ virtualenv==20.29.2
 webencodings==0.5.1
 websocket-client==1.8.0
 Werkzeug==3.1.3
+

--- a/src/backend/LockScreenManager/Detectors/Hyprland.py
+++ b/src/backend/LockScreenManager/Detectors/Hyprland.py
@@ -1,0 +1,22 @@
+from src.backend.LockScreenManager.LockScreenDetector import LockScreenDetector
+import globals as gl
+from src.backend.Wayland.WaylandSignals import HyprlandLock, HyprlandUnlock
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.backend.LockScreenManager.LockScreenManager import LockScreenManager
+
+class HyprlandLockScreenDetector(LockScreenDetector):
+    def __lock(self):
+        self.lock_screen_manager.lock(True)
+
+    def __unlock(self):
+        self.lock_screen_manager.lock(False)
+
+    def __init__(self, lock_screen_manager: "LockScreenManager"):
+        super().__init__(lock_screen_manager)
+
+        gl.signal_manager.connect_signal(signal=HyprlandLock, callback=self.__lock)
+
+        gl.signal_manager.connect_signal(signal=HyprlandUnlock, callback=self.__unlock)

--- a/src/backend/LockScreenManager/LockScreenManager.py
+++ b/src/backend/LockScreenManager/LockScreenManager.py
@@ -16,6 +16,7 @@ import os
 from src.backend.LockScreenManager.Detectors.Gnome import GnomeLockScreenDetector
 from src.backend.LockScreenManager.Detectors.Cinnamon import CinnamonLockScreenDetector
 from src.backend.LockScreenManager.Detectors.KDE import KDELockScreenDetector
+from src.backend.LockScreenManager.Detectors.Hyprland import HyprlandLockScreenDetector
 from src.backend.LockScreenManager.LockScreenDetector import LockScreenDetector
 from loguru import logger as log
 
@@ -36,6 +37,8 @@ class LockScreenManager:
             self.detector = CinnamonLockScreenDetector(self)
         elif env == "kde":
             self.detector = KDELockScreenDetector(self)
+        elif env == "hyprland":
+            self.detector = HyprlandLockScreenDetector(self)
 
     @log.catch
     def get_active_environment(self) -> str:

--- a/src/backend/Wayland/Wayland.py
+++ b/src/backend/Wayland/Wayland.py
@@ -1,0 +1,49 @@
+import threading
+import time
+
+import wayland
+from os import getenv
+import globals as gl
+from loguru import logger as log
+
+from src.Signals.Signals import AppQuit
+from src.backend.Wayland import WaylandSignals
+
+
+class Wayland:
+    def __on_wl_registry_global(self, name, interface, version):
+        if interface == "hyprland_lock_notifier_v1":
+            log.debug("Hyprland lock notifier found, hooking...")
+            wayland.wl_registry.bind(name, interface, version, name)
+            wayland.hyprland_lock_notifier_v1.get_lock_notification()
+
+    def __on_lock(self):
+        gl.signal_manager.trigger_signal(WaylandSignals.HyprlandLock)
+
+    def __on_unlock(self):
+        gl.signal_manager.trigger_signal(WaylandSignals.HyprlandUnlock)
+
+    def __on_quit(self):
+        self.__quit = True
+
+    def __tick_wayland_messages_threaded(self):
+        while not self.__quit:
+            wayland.process_messages()
+            time.sleep(self.__TICK_DELAY)
+
+    def __init__(self):
+        self.__quit = False
+        self.__TICK_DELAY = 0.1
+        if not getenv("WAYLAND_DISPLAY", False):
+            raise(EnvironmentError("Attempted to initialize Wayland when WAYLAND_DISPLAY is not set"))
+        wayland.initialise(True)
+
+        gl.signal_manager.connect_signal(AppQuit, self.__on_quit)
+
+        wayland.wl_registry.events.global_ += self.__on_wl_registry_global
+        wayland.hyprland_lock_notification_v1.events.locked += self.__on_lock
+        wayland.hyprland_lock_notification_v1.events.unlocked += self.__on_unlock
+
+        wayland.wl_display.get_registry()
+
+        threading.Thread(target=self.__tick_wayland_messages_threaded, name="tick_wayland_messages_threaded").start()

--- a/src/backend/Wayland/WaylandSignals.py
+++ b/src/backend/Wayland/WaylandSignals.py
@@ -1,0 +1,7 @@
+from src.Signals.Signals import Signal
+
+class HyprlandLock(Signal):
+    pass
+
+class HyprlandUnlock(Signal):
+    pass

--- a/src/windows/Settings/Settings.py
+++ b/src/windows/Settings/Settings.py
@@ -649,7 +649,7 @@ class SystemGroup(Adw.PreferencesGroup):
         self.autostart = Adw.SwitchRow(title=gl.lm.get("settings-system-settings-autostart"), subtitle=gl.lm.get("settings-system-settings-autostart-subtitle"), active=True)
         self.add(self.autostart)
 
-        self.lock_on_lock_screen = Adw.SwitchRow(title="Lock decks when screen is locked", subtitle="Only works on Gnome", active=True)
+        self.lock_on_lock_screen = Adw.SwitchRow(title="Lock decks when screen is locked", subtitle="Works on Gnome, KDE, Cinnamon and Hyprland", active=True)
         self.add(self.lock_on_lock_screen)
 
         self.beta_resume_mode = Adw.SwitchRow(title="Use new resume mode (beta)", subtitle="Use new way to resume after suspends - requires restart", active=False)


### PR DESCRIPTION
Relevant Issue: #372 

This pull request implements a wayland socket communicator and hyprland screen lock support.

Testing:
Ensured app still launches under X11 and XWayland.
When launched without `WAYLAND_DISPLAY` (either X11 or XWayland), the `gl.wayland` global is not created.

To be resolved in draft:
New message format for lock screen settings message
- Seeing as there is now support for GNOME, KDE, Cinnamon and Hyprland, I feel like tacking on each supported DE/WM will end up causing a very long text entry if more are added in the future. Looking for feedback for the message format here

reqs.yaml and pypi-requirements.yaml
- I'm not sure if these should be updated within each PR, or if that's a packaging job.
- I can't seem to generate the pypi-requirements.yaml file. It looks distinct from reqs.yaml in the current upstream commit, and both files only include the command to generate reqs.yaml