### PR TITLE
Feat(GenerativeUI): Forgot to add False passing in ComboRow

### DIFF
--- a/GtkHelper/GenerativeUI/ComboRow.py
+++ b/GtkHelper/GenerativeUI/ComboRow.py
@@ -100,7 +100,7 @@ class ComboRow(GenerativeUI[BaseComboRowItem]):
     def load_initial_ui(self):
         value = self.get_value()
         selected_item = self.widget.set_selected_item(value)
-        self._handle_value_changed(selected_item)
+        self._handle_value_changed(selected_item, False)
 
     @GenerativeUI.signal_manager
     def set_ui_value(self, value: BaseComboRowItem | str):


### PR DESCRIPTION
As ComboRows implement the `load_initial_ui` seperately it also needs to pass `False` so settings dont get updated when loading for the first time