### PR TITLE
fix(store): dont fail to load store if a single plugin is misconfigured

### DIFF
--- a/src/backend/Store/StoreBackend.py
+++ b/src/backend/Store/StoreBackend.py
@@ -307,7 +307,11 @@ class StoreBackend:
 
         manifest = await self.get_manifest(url, commit or branch)
         if isinstance(manifest, NoConnectionError):
+            log.error(f"manifest failed to load due to NoConnectionError for repository {url}")
             return manifest
+        if not manifest:
+            log.error(f"manifest failed to load for repository {url}")
+            return
 
         image = None
         thumbnail_path = manifest.get("thumbnail")

--- a/src/windows/Onboarding/PluginRecommendations.py
+++ b/src/windows/Onboarding/PluginRecommendations.py
@@ -57,6 +57,8 @@ class PluginRecommendations(Gtk.Box):
         plugins = gl.store_backend.get_all_plugins()
 
         for plugin in plugins:
+            if not plugin:
+                continue
             if not plugin.is_compatible:
                 continue
 

--- a/src/windows/Store/Plugins/PluginPage.py
+++ b/src/windows/Store/Plugins/PluginPage.py
@@ -62,6 +62,8 @@ class PluginPage(StorePage):
             self.show_connection_error()
             return
         for plugin in plugins:
+            if not plugin:
+                continue
             if plugin.is_compatible:
                 section = self.compatible_section
             else:


### PR DESCRIPTION
Currently, if a plugin has a misconfigured manifest or if someone provides an invalid custom repository that is invalid,
the entire store will fail to load and will continue to load indefinitely. This change makes sure that if there is no
valid manifest for a plugin, we just skip it and continue on to the next plugin in the list.
