### PR TITLE
fix(icon): use more distinct path for icon

### DIFF
--- a/src/tray.py
+++ b/src/tray.py
@@ -18,7 +18,7 @@ class TrayIcon(DBusTrayIcon):
         self.menu.add_menu_item(6, menu_type="separator")
         self.menu.add_menu_item(7, "Quit", callback=self.on_quit)
         super().__init__(self.menu, self.MenuPath, self.IndicatorPath, self.AppId, "StreamController")
-        self.set_icon("com.core447.StreamController", os.path.join(gl.top_level_dir, "Assets", "icons"))
+        self.set_icon("com.core447.StreamController", os.path.join(gl.top_level_dir, "Assets", "icons", "hicolor", "scalable", "apps"))
         self.set_tooltip("StreamController")
         self.set_label("StreamController")
 


### PR DESCRIPTION
My previous fix for the icon to work on Plasma (#392) broke icon display
on Gnome. It looks as though the appindicator logic in Gnome doesn't
properly scan subdirectories for icons like KDE does (#421). Setting the
full path to our icon allows Gnome appindicator to work, along with 
plasma still working as well. This also fixes the issue with ironbar (#428)
as it also seems to just pick the first icon it can find that matches
the name instead of looking in the correct path.

Tested against the following setups:
- Gnome with appindicator
- hyprland with ironbar
- KDE Plasma
- XFCE X11
