### PR TITLE
feat: CLI commands for device management & state control

### DIFF
--- a/globals.py
+++ b/globals.py
@@ -15,6 +15,16 @@ argparser.add_argument("--skip-load-hardware-decks", help="Skips initilization/u
 argparser.add_argument("--close-running", help="Close running", action="store_true")
 argparser.add_argument("--data", help="Data path", type=str)
 argparser.add_argument("--change-page", action="append", nargs=2, help="Change the page for a device", metavar=("SERIAL_NUMBER", "PAGE_NAME"))
+argparser.add_argument("--list-devices", help="List all connected StreamDeck devices and their properties", action="store_true")
+argparser.add_argument("--list-pages", help="List all available pages", action="store_true")
+argparser.add_argument("--change-state", action="append", nargs=4, 
+                      help="Change the state of a StreamDeck item. Format: SERIAL PAGE COORDS STATE\n"
+                           "  SERIAL: Device serial number (e.g., CL123456789)\n"
+                           "  PAGE: Page name (e.g., Main, Soundboard) \n"
+                           "  COORDS: Position as x,y (e.g., 0,0 for top-left)\n"
+                           "  STATE: State number to change to (0, 1, 2, etc.)\n"
+                           "Example: --change-state CL123456789 Main 0,0 1", 
+                      metavar=("SERIAL", "PAGE", "COORDS", "STATE"))
 argparser.add_argument("app_args", nargs="*")
 
 MAIN_PATH: str
@@ -104,12 +114,13 @@ store_backend: "StoreBackend" = None
 pyro_daemon: Pyro5.api.Daemon = None
 signal_manager: "SignalManager" = None
 window_grabber: "WindowGrabber" = None
-lock_screen_detector: "LockScreenDetector" = None
+lock_screen_detector: "LockScreenManager" = None
 store: "Store" = None # Only if opened
 flatpak_permission_manager: "FlatpakPermissionManager" = None
 threads_running: bool = True
 app_loading_finished_tasks: callable = []
 api_page_requests: dict[str, str] = {} # Stores api page requests made my --change-page
+api_state_requests: dict[str, dict] = {} # Stores api state change requests made by --change-state
 tray_icon: "TrayIcon" = None
 fallback_font: str = find_fallback_font()
 showed_donate_window: bool = False


### PR DESCRIPTION
This feature has been requested in this issue: #164 

### What’s new
- Device discovery  
  - `--list-devices`: shows ID, product name, serial, key layout, connection status; prints permission tips if access fails.  
  - `--list-pages`: lists every page, its items, and state counts.

- State control  
  - `--change-state SERIAL PAGE COORD STATE`: changes a single key’s state. Works via D-Bus if StreamController is running, or directly if not.

### Help Documentation
I added the new commands to the documentation, here is what the help functions now additionally states.
```
  --list-devices        List all connected StreamDeck devices and their properties
  --list-pages          List all available pages
  --change-state SERIAL PAGE COORDS STATE
                        Change the state of a StreamDeck item. Format: SERIAL PAGE COORDS STATE SERIAL: Device serial number (e.g., CL123456789) PAGE: Page name (e.g., Main, Soundboard) COORDS:
                        Position as x,y (e.g., 0,0 for top-left) STATE: State number to change to (0, 1, 2, etc.) Example: --change-state CL123456789 Main 0,0 1
```

### Files touched
- `globals.py` — CLI arg definitions, API request storage  
- `main.py` — listing commands, validation, API calls  
- `app.py` — D-Bus handler for `change_state`  
- `DeckController.py` — processes state-change requests at init

### Typical uses
- Check connected StreamDecks quickly  
- Script key-state changes 
  - thereby enabling companion applications to interact with StreamController item states
- Debug layouts and permissions

### Compatibility
Additive only; existing commands and APIs are untouched.