### PR TITLE
Restore missing translation in onboarding guide

### DIFF
--- a/locales/locales.csv
+++ b/locales/locales.csv
@@ -96,7 +96,7 @@ store.wallpapers.search-placeholder;Nach Hintergründen suchen;Search for wallpa
 onboarding.welcome.header;Willkommen bei StreamController!;Welcome To StreamController!;Bienvenue chez StreamController !;Bienvenido a StreamController
 onboarding.welcome.details;Die Linux App für das Elgato Stream Deck;The Linux app for the Elgato Stream Deck;L'application Linux pour le Stream Deck d’Elgato;La aplicación Linux para Elgato Stream Deck
 onboarding.store.header;Asset Store;Asset Store;Magasin de ressources;Tienda
-onboarding.store.details;Plugins; Icons und Hintergründe herunterladen;Télécharger des plugins;Búsqueda de iconos y fondos de pantalla
+onboarding.store.details;Icons und Hintergründe herunterladen;Download plugins;Télécharger des plugins;Búsqueda de iconos y fondos de pantalla
 onboarding.productive.header;Produktiver;Be More Productive;Soyez plus productif;Sea más productivo
 onboarding.productive.details;Mit eigenen Makros & Routinen;With your personal shortcuts;Avec vos raccourcis personnalisés;Con tus atajos personales
 onboarding.multiple.header;Multi Deck Support;Multi Deck Support;Support Multi Deck;Soporte Multi Deck


### PR DESCRIPTION
Looks like the English text for `onboarding.store.details` got lost in c8962b32bd1225116877b31ab7fd7932baf66a5f