### PR TITLE
fix(store): Check status code when receiving a response

### DIFF
--- a/src/backend/Store/StoreBackend.py
+++ b/src/backend/Store/StoreBackend.py
@@ -106,6 +106,8 @@ class StoreBackend:
             req = requests.get(url, stream=True)
             if req.status_code == 200:
                 return req
+            log.error(f"Request to {url} failed with status code {req.status_code}")
+            return NoConnectionError()
         except requests.exceptions.ConnectionError as e:
             log.error(e)
             return NoConnectionError()


### PR DESCRIPTION
The requests library does not throw an exception on all non 2xx codes, for example 429. This seems to be happening frequently from GitHub so
this change is designed to make sure we validate the status code, and if it is not what we expect, return an error that the rest of the 
application already knows how to handle
