### PR TITLE
fix(store): If attribution.json is missing, don't prevent loading of plugin

### DIFF
--- a/src/backend/Store/StoreBackend.py
+++ b/src/backend/Store/StoreBackend.py
@@ -289,7 +289,7 @@ class StoreBackend:
     async def get_attribution(self, url:str, commit:str) -> dict:
         result = await self.get_remote_file(url, "attribution.json", commit)
         if isinstance(result, NoConnectionError):
-            return result
+            return {}
         
         try:
             return json.loads(result)


### PR DESCRIPTION
The previous fix in #490 caused caused an issue where if attribution.json is missing,
the plugin would fail to load in the store. Since attribution.json is not required,
this makes sure to return an empty value, which is valid
