### PR TITLE
fix(threading): Join all threads on shutdown to make sure they are released

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -187,8 +187,10 @@ class App(Adw.Application):
         gl.plugin_manager.loop_daemon = False
         log.debug("non-daemon threads:")
         for thread in threading.enumerate():
-            if thread.daemon:
-                continue
+            if thread is not threading.current_thread():
+                thread.join(timeout=2.0)
+                if thread.is_alive():
+                    log.error(f"Thread {thread.name} did not exit in time")
             log.debug(f"name: {thread.name}, id: {thread.ident} id2: {thread.native_id}")
 
         for child in multiprocessing.active_children():


### PR DESCRIPTION
Everytime StreamController shuts down we get the following errors:

```
StreamController: os/threads_posix.h:58: usbi_mutex_destroy:
Assertion `pthread_mutex_destroy(mutex) == 0' failed.
StreamController: os/threads_posix.h:46: usbi_mutex_lock: Assertion `pthread_mutex_lock(mutex) == 0' failed.
```
This sometimes causes an issue where the deck isn't fully released, leading to USB device contention.
This change makes sure we join the threads properly so they have time to shutdown, with a short but sensible
timeout value to make sure we don't hang indefinitely.

After implementing this change, I no longer see those errors, and do not see any threads reported as being
hung.
