### PR TITLE
Fix shutdown issues

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -184,14 +184,15 @@ class App(Adw.Application):
         for ctrl in gl.deck_manager.deck_controller:
             ctrl.delete()
 
+        gl.deck_manager.stop_usb_monitoring()
+
         gl.plugin_manager.loop_daemon = False
-        log.debug("non-daemon threads:")
+
         for thread in threading.enumerate():
-            if thread is not threading.current_thread():
-                thread.join(timeout=2.0)
+            if thread is not threading.current_thread() and not thread.daemon:
+                thread.join(timeout=5)
                 if thread.is_alive():
                     log.error(f"Thread {thread.name} did not exit in time")
-            log.debug(f"name: {thread.name}, id: {thread.ident} id2: {thread.native_id}")
 
         for child in multiprocessing.active_children():
             child.terminate()
@@ -202,6 +203,7 @@ class App(Adw.Application):
         gl.deck_manager.close_all()
         # Stop timer
         log.success("Stopped StreamController. Have a nice day!")
+        log.stop()
         sys.exit(0)
 
     def force_quit(self):

--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -208,6 +208,9 @@ class DeckManager:
             controller.clear()
             controller.deck.close()
 
+    def stop_usb_monitoring(self):
+        self.usb_monitor.stop_monitoring(timeout=2)
+
     def reset_all_decks(self):
         # Find all USB devices
         devices = usb.core.find(find_all=True)


### PR DESCRIPTION
I've noticed that when the app is shutting down, it often hangs for a few seconds, sometimes upwards of 10. This change helps address that by doing the following:
- Call the safe `stop_monitoring()` function of `USBMonitor`
- Call the safe `stop()` function of `loguru`
- Ignore some specific threads that we don't want/can't terminate

Doing some initial testing, StreamController now quits within 2 seconds during most of my testing