### PR TITLE
fix(KeyGrid): Set fixed size and pixel size for key button images

### DIFF
--- a/src/windows/mainWindow/elements/KeyGrid.py
+++ b/src/windows/mainWindow/elements/KeyGrid.py
@@ -142,6 +142,8 @@ class KeyButton(Gtk.Frame):
 
         self.image = Gtk.Image(hexpand=True, vexpand=True, css_classes=["key-image", "key-button"])
         self.image.set_overflow(Gtk.Overflow.HIDDEN)
+        self.image.set_size_request(75, 75)
+        self.image.set_pixel_size(75)
         self.set_child(self.image)
 
         # self.button.connect("clicked", self.on_click)


### PR DESCRIPTION
Before:
<img width="457" height="428" alt="image" src="https://github.com/user-attachments/assets/35882884-f8e2-4f39-8777-0bbd8c353932" />

After
<img width="464" height="421" alt="image" src="https://github.com/user-attachments/assets/688564e0-c192-4acd-b983-216653eeb001" />
