### PR TITLE
feat: Add alignment property to labels and implement touch bar background

### DIFF
--- a/locales/locales.csv
+++ b/locales/locales.csv
@@ -8,6 +8,7 @@ label-editor-bottom-name;Unten;Bottom;Bas;Abajo
 label-editor-font-chooser-label;Schriftart:;Font:;Police :;Fuente:
 label-editor-outline-width-label;Randdicke:;Outline width:;Largeur du contour:;Ancho del contorno:
 label-editor-outline-color-label;Randfarbe:;Outline color:;Couleur du contour:;Color de contorno:
+label-editor-alignment-label;Ausrichtung:;Align:;Alignement :;Alineación:
 label-editor-placeholder-text;Text;Label;Étiquette;Etiqueta
 label-editor-expander-subtitle;Texte für diese Taste;Labels for this key;Étiquettes de ce bouton;Etiquetas para esta tecla
 action-editor-header;Aktions;Actions;Actions;Acciones

--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -690,8 +690,10 @@ class DeckController:
 
         if self.background.video is not None:
             self.background.video.close()
+            self.background.video = None
         if self.background.image is not None:
             self.background.image.close()
+            self.background.image = None
 
     @log.catch
     def load_page(self, page: Page, load_brightness: bool = True, load_screensaver: bool = True, load_background: bool = True, load_inputs: bool = True, allow_reload: bool = True):

--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -1256,6 +1256,7 @@ class LabelManager:
                 "font-style": False,
                 "outline_width": False,
                 "outline_color": False,
+                "alignment": False,
             }
         return {
             "text": self.page_labels[position].text is not None,
@@ -1266,6 +1267,7 @@ class LabelManager:
             "font-style": self.page_labels[position].style is not None,
             "outline_width": self.page_labels[position].outline_width is not None,
             "outline_color": self.page_labels[position].outline_color is not None,
+            "alignment": self.page_labels[position].alignment is not None,
         }
 
     def get_composed_label(self, position: str) -> str:
@@ -1292,6 +1294,8 @@ class LabelManager:
                 label.outline_width = page_label.outline_width
             if use_page_label_properties["outline_color"]:
                 label.outline_color = page_label.outline_color
+            if use_page_label_properties["alignment"]:
+                label.alignment = page_label.alignment
 
         injected = self.inject_defaults(label)
         return self.fix_invalid(injected)
@@ -1320,6 +1324,8 @@ class LabelManager:
             label.outline_width = round(gl.settings_manager.font_defaults.get("outline-width") or 2)
         if label.outline_color is None:
             label.outline_color = gl.settings_manager.font_defaults.get("outline-color") or (0, 0, 0, 255)
+        if label.alignment is None:
+            label.alignment = gl.settings_manager.font_defaults.get("alignment") or "center"
 
         return label
     
@@ -1358,18 +1364,29 @@ class LabelManager:
             font = labels[label].get_font()
             outline_width = labels[label].outline_width
             outline_color = tuple(labels[label].outline_color)
+            alignment = labels[label].alignment
 
             _, _, w, h = draw.textbbox((0, 0), text, font=font)
 
-            # Center
-            x_position = image.width / 2
+            # Calculate x position based on alignment
+            padding = 3
+            if alignment == "left":
+                x_position = padding
+                anchor_x = "l"
+            elif alignment == "right":
+                x_position = image.width - padding
+                anchor_x = "r"
+            else:  # center (default)
+                x_position = image.width / 2
+                anchor_x = "m"
 
             if image.width < w:
-                # Need to scroll
+                # Need to scroll - always use center anchor for scrolling
                 start = image.width / 2 - (image.width - w) / 2 + 10
                 stop = image.width / 2 + (image.width - w) / 2 - 10
 
                 x_position = start - self.frames[label]["position"]
+                anchor_x = "m"
                 if x_position < stop:
                     if self.frames[label]["wait"] == 0:
                         x_position = start
@@ -1394,8 +1411,11 @@ class LabelManager:
             else:
                 position = (x_position, (image.height - 0) / 2)
 
+            # Use appropriate anchor based on alignment (x-anchor + "m" for vertical middle)
+            anchor = anchor_x + "m"
+
             draw.text(position,
-                      text=text, font=font, anchor="mm", align="center",
+                      text=text, font=font, anchor=anchor, align=alignment,
                       fill=color, stroke_width=outline_width,
                       stroke_fill=outline_color)
 
@@ -2176,7 +2196,8 @@ class ControllerKey(ControllerInput):
                         font_name=state_dict["labels"][label].get("font-family"),
                         color=state_dict["labels"][label].get("color"),
                         outline_width=state_dict["labels"][label].get("outline_width"),
-                        outline_color=state_dict["labels"][label].get("outline_color")
+                        outline_color=state_dict["labels"][label].get("outline_color"),
+                        alignment=state_dict["labels"][label].get("alignment")
                     )
                     # self.add_label(key_label, position=label, update=False)
                     state.label_manager.set_page_label(label, key_label, update=False)
@@ -2477,6 +2498,7 @@ class ControllerDial(ControllerInput):
                     font_size=state_dict["labels"][label].get("font-size"),
                     font_name=state_dict["labels"][label].get("font-family"),
                     color=state_dict["labels"][label].get("color"),
+                    alignment=state_dict["labels"][label].get("alignment"),
                 )
                 state.label_manager.set_page_label(label, key_label, update=False)
 
@@ -2558,8 +2580,56 @@ class ControllerTouchScreenState(ControllerInputState):
         self.update()
 
     def get_current_image(self) -> Image.Image:
-        background = self.controller_touch.generate_empty_image()
+        screen_width, screen_height = self.controller_touch.get_screen_dimensions()
+        
+        # Start with background image if set
+        background: Image.Image = None
+        active_page = self.controller_touch.deck_controller.active_page
+        background_image_path = active_page.get_background_image(
+            identifier=self.controller_touch.identifier, 
+            state=self.state
+        )
+        
+        if background_image_path and os.path.isfile(background_image_path):
+            try:
+                with Image.open(background_image_path) as img:
+                    # Resize to exact touchscreen dimensions (KISS - exact dimensions)
+                    background = img.resize((screen_width, screen_height), Image.Resampling.LANCZOS).convert("RGBA")
+            except Exception as e:
+                log.error(f"Error loading background image: {e}")
+                background = None
+        
+        # Get background color from touchscreen state's background_manager
+        background_color = self.background_manager.get_composed_color()
+        
+        # If no background image, start with empty or colored background
+        if background is None:
+            # If background color has transparency (alpha < 255), start with transparent
+            if background_color[-1] < 255:
+                background = self.controller_touch.generate_empty_image()
+            
+            # If background color is set (alpha > 0), create colored background
+            if background_color[-1] > 0:
+                background_color_img = Image.new("RGBA", (screen_width, screen_height), color=tuple(background_color))
+                
+                if background is None:
+                    # Use the color as the only background - happens if background color alpha is 255
+                    background = background_color_img
+                else:
+                    # Paste color on top of transparent background
+                    background.paste(background_color_img, (0, 0), background_color_img)
+            
+            # If no background color was set, use empty image
+            if background is None:
+                background = self.controller_touch.generate_empty_image()
+        else:
+            # Background image exists - apply color overlay if set
+            if background_color[-1] > 0:
+                background_color_img = Image.new("RGBA", (screen_width, screen_height), color=tuple(background_color))
+                # Blend color over image
+                background = Image.alpha_composite(background, background_color_img)
 
+        # Paste dial images on top of the background
         for dial in self.controller_touch.deck_controller.inputs[Input.Dial]:
             state = dial.get_active_state()
             image_area = self.controller_touch.get_dial_image_area(dial.identifier)

--- a/src/backend/DeckManagement/Subclasses/KeyLabel.py
+++ b/src/backend/DeckManagement/Subclasses/KeyLabel.py
@@ -34,6 +34,7 @@ class KeyLabel:
     color: list[int] = None
     outline_width: int = None
     outline_color: list[int] = None
+    alignment: str = None  # left, center, right
 
     def get_font_path(self) -> str:
         font_name = self.font_name
@@ -60,6 +61,7 @@ class KeyLabel:
         self.color = None
         self.outline_width = None
         self.outline_color = None
+        self.alignment = None
 
     def get_font(self) -> ImageFont.FreeTypeFont:
         return ImageFont.truetype(self.get_font_path(), self.font_size)

--- a/src/backend/PageManagement/Page.py
+++ b/src/backend/PageManagement/Page.py
@@ -856,6 +856,20 @@ class Page:
         if update:
             self.update_input(identifier, state)
 
+    def set_label_alignment(self, identifier: InputIdentifier, state: int, label_position: str, alignment: str, update: bool = True) -> None:
+        for key_state in self.get_controller_input_states(identifier, state):
+            key_state.label_manager.page_labels[label_position].alignment = alignment
+
+        self._set_dict_value([identifier.input_type, identifier.json_identifier, "states", str(state), "labels", label_position, "alignment"], alignment)
+
+        label_manager = self.get_label_manager(identifier, state)
+        if label_manager is not None:
+            label_manager.page_labels[label_position].alignment = alignment
+            label_manager.update_label_editor()
+
+        if update:
+            self.update_input(identifier, state)
+
     def get_media_size(self, identifier: InputIdentifier, state: int) -> float:
         return self._get_dict_value([identifier.input_type, identifier.json_identifier, "states", str(state), "media", "size"])
 
@@ -912,6 +926,14 @@ class Page:
             key_state.background_manager.set_page_color(color, update=update, update_ui=update_ui)
 
         self._set_dict_value([identifier.input_type, identifier.json_identifier, "states", str(state), "background", "color"], color)
+
+    def get_background_image(self, identifier: InputIdentifier, state: int) -> str:
+        return self._get_dict_value([identifier.input_type, identifier.json_identifier, "states", str(state), "background", "image"])
+
+    def set_background_image(self, identifier: InputIdentifier, state: int, path: str, update: bool = True) -> None:
+        self._set_dict_value([identifier.input_type, identifier.json_identifier, "states", str(state), "background", "image"], path)
+        if update:
+            self.update_input(identifier, state)
 
 
 class NoActionHolderFound:

--- a/src/windows/mainWindow/elements/Sidebar/elements/ScreenEditor.py
+++ b/src/windows/mainWindow/elements/Sidebar/elements/ScreenEditor.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from src.backend.DeckManagement.InputIdentifier import Input
 from src.windows.mainWindow.elements.Sidebar.elements.ActionManager import ActionManager
+from src.windows.mainWindow.elements.Sidebar.elements.BackgroundEditor import BackgroundEditor
 from src.windows.mainWindow.elements.Sidebar.elements.StateSwitcher import StateSwitcher
 from src.windows.mainWindow.DeckPlus.ScreenBar import ScreenBarImage
 
@@ -36,6 +37,9 @@ class ScreenEditor(Gtk.ScrolledWindow):
         self.state_switcher.add_add_new_callback(self.on_add_new_state)
         self.state_switcher.set_n_states(0)
         self.main_box.append(self.state_switcher)
+
+        self.background_editor = BackgroundEditor(self.sidebar, margin_top=25)
+        self.main_box.append(self.background_editor)
 
         self.action_manager_group = Adw.PreferencesGroup(title="Actions")
         self.main_box.append(self.action_manager_group)
@@ -107,4 +111,5 @@ class ScreenEditor(Gtk.ScrolledWindow):
 
         self.remove_state_button.set_visible(self.state_switcher.get_n_states() > 1)
 
+        self.background_editor.load_for_identifier(identifier, state)
         self.action_manager.load_for_identifier(identifier, state)


### PR DESCRIPTION
## Pull Request: Add Label Alignment & Touchbar Background Image Support

### 🎯 Summary

This PR introduces two key features:
1. **Label Alignment Control** - Users can now align key/dial labels to left, center, or right
2. **Touchbar Background Images** - Full support for custom background images on Stream Deck Plus touchbars

---

### ✨ Features

#### Label Alignment Property

Adds horizontal text alignment options for key labels, giving users more control over label positioning.

**Changes:**
- Added `alignment` field to `KeyLabel` dataclass with values: `"left"`, `"center"`, `"right"`
- New `AlignmentButtons` widget in the Label Editor with intuitive toggle buttons
- Text rendering now respects alignment when positioning labels
- Alignment is composable (page → action) and supports reset to default

**UI:**

| Component | Description |
|-----------|-------------|
| Left button | `format-justify-left-symbolic` icon |
| Center button | `format-justify-center-symbolic` icon |
| Right button | `format-justify-right-symbolic` icon |

#### Touchbar Background Image Handling

Enables users to set custom background images for the Stream Deck Plus touchbar/touchscreen.

**Changes:**
- New `ImageRow` in `BackgroundEditor` for touchscreen inputs
- Image selection via asset chooser with preview thumbnail
- Background images are resized to exact touchscreen dimensions
- Supports layering: background image → background color overlay → dial images
- Clear button to remove background image

---

### 📁 Files Changed

| File | Changes |
|------|---------|
| `src/backend/DeckManagement/Subclasses/KeyLabel.py` | Added `alignment` property |
| `src/backend/DeckManagement/DeckController.py` | Label alignment rendering, touchscreen background image loading |
| `src/backend/PageManagement/Page.py` | Added `set_label_alignment()`, `get_background_image()`, `set_background_image()` |
| `src/windows/mainWindow/elements/Sidebar/elements/LabelEditor.py` | New `AlignmentButtons` widget and handlers |
| `src/windows/mainWindow/elements/Sidebar/elements/BackgroundEditor.py` | New `ImageRow` for touchscreen backgrounds |
| `src/windows/mainWindow/elements/Sidebar/elements/ScreenEditor.py` | Added `BackgroundEditor` to touchscreen sidebar |

---

### 🔧 Technical Details

**Label Alignment Logic:**
- Alignment affects both text anchor point and x-position calculation
- Left alignment uses padding from left edge
- Right alignment uses padding from right edge  
- Center alignment (default) centers text horizontally

**Background Image Compositing Order:**
1. Load background image (if set) → resize to touchscreen dimensions
2. Apply background color overlay (if alpha > 0)
3. Composite dial images on top

---

### 🧪 Testing

- [x] Test label alignment on keys (left/center/right)
- [x] Test label alignment on dials
- [x] Test alignment persistence across page reloads
- [x] Test alignment reset button functionality
- [x] Test touchbar background image selection
- [x] Test touchbar background image with color overlay
- [x] Test touchbar background image clear functionality
- [x] Test that ImageRow only appears for touchscreen inputs

---

### 📝 Notes

- Default alignment is `"center"` (backwards compatible)
- Alignment UI is hidden when label text is empty
- Background image support is exclusive to touchscreen inputs (Stream Deck Plus)

---
<img width="474" height="425" alt="image" src="https://github.com/user-attachments/assets/f332a890-a6ff-4a1d-b90c-56f9f3d3c2a1" />
<img width="497" height="464" alt="image" src="https://github.com/user-attachments/assets/71306ec7-ba2f-46d3-8911-105131d05757" />
<img width="1188" height="588" alt="image" src="https://github.com/user-attachments/assets/894aba33-b22e-45c3-be5b-fe6500a736c4" />
<img width="1188" height="525" alt="image" src="https://github.com/user-attachments/assets/4e3bd9c2-e91b-49bb-9cf1-ad66eadd50f8" />
<img width="456" height="430" alt="image" src="https://github.com/user-attachments/assets/4670f201-8e37-4240-8710-f4798c376d50" />
<img width="536" height="470" alt="image" src="https://github.com/user-attachments/assets/815cc1ad-b95d-4051-8782-fe0f027a7c5d" />

