### PR TITLE
Fix memory leak in SignalManager causing 9+ GB RAM usage

### DIFF
--- a/src/Signals/SignalManager.py
+++ b/src/Signals/SignalManager.py
@@ -25,19 +25,63 @@ class SignalManager:
         # Verify signal
         if not issubclass(signal, Signal):
             raise TypeError("signal_name must be of type Signal")
-        
+
         # Verify callback
         if not callable(callback):
             raise TypeError("callback must be callable")
-        
+
         self.connected_signals.setdefault(signal, [])
         self.connected_signals[signal].append(callback)
+
+    def disconnect_signal(self, signal: Signal, callback: callable) -> bool:
+        """
+        Disconnects a callback from a signal.
+
+        Args:
+            signal: The signal class to disconnect from
+            callback: The callback to remove
+
+        Returns:
+            True if the callback was found and removed, False otherwise
+        """
+        # Verify signal
+        if not issubclass(signal, Signal):
+            raise TypeError("signal must be of type Signal")
+
+        if signal not in self.connected_signals:
+            return False
+
+        try:
+            self.connected_signals[signal].remove(callback)
+            return True
+        except ValueError:
+            return False
+
+    def disconnect_all_for_callback(self, callback: callable) -> int:
+        """
+        Disconnects a callback from all signals it may be connected to.
+
+        Args:
+            callback: The callback to remove from all signals
+
+        Returns:
+            The number of signals the callback was disconnected from
+        """
+        count = 0
+        for signal in self.connected_signals:
+            try:
+                while callback in self.connected_signals[signal]:
+                    self.connected_signals[signal].remove(callback)
+                    count += 1
+            except ValueError:
+                pass
+        return count
 
     def trigger_signal(self, signal: Signal, *args, **kwargs) -> None:
         # Verify signal
         if not issubclass(signal, Signal):
             raise TypeError("signal must be of type Signal")
-        
+
         for callback in self.connected_signals.get(signal, []):
             if signal == AppQuit:
                 callback(*args, **kwargs)

--- a/src/backend/PageManagement/Page.py
+++ b/src/backend/PageManagement/Page.py
@@ -571,14 +571,13 @@ class Page:
             for input_identifier in self.action_objects[input_type]:
                 for state in self.action_objects[input_type][input_identifier]:
                     for i, action in enumerate(list(self.action_objects[input_type][input_identifier][state].values())):
-                        self.action_objects[input_type][input_identifier][state][i].page = None
-                        self.action_objects[input_type][input_identifier][state][i] = None
-                        if isinstance(self.action_objects[input_type][input_identifier][state][i], ActionCore):
-                            if hasattr(self.action_objects[input_type][input_identifier][state][i], "on_removed_from_cache"):
-                                self.action_objects[input_type][input_identifier][state][i].on_removed_from_cache()
-                        self.action_objects[input_type][input_identifier][state][i] = None
-                        del self.action_objects[input_type][input_identifier][state][i]
+                        # Call cleanup BEFORE clearing references
+                        if isinstance(action, ActionCore):
+                            if hasattr(action, "on_removed_from_cache"):
+                                action.on_removed_from_cache()
+                        action.page = None
             self.action_objects[input_type] = {}
+        self.action_objects = {}
 
     def get_name(self):
         return os.path.splitext(os.path.basename(self.json_path))[0]


### PR DESCRIPTION
## Summary
- Fixes memory leak where `SignalManager` callbacks accumulated indefinitely, preventing garbage collection of action objects
- After days of running, `flatpak-session-helper` would grow to 9+ GB RAM

## Changes
- Add `disconnect_signal()` and `disconnect_all_for_callback()` methods to `SignalManager`
- Track signal connections in `ActionCore._connected_signals`
- Implement `on_removed_from_cache()` to clean up signals automatically when actions are removed
- Fix bug in `Page.clear_action_objects()` that set action to `None` before calling cleanup methods

## Root Cause
The `SignalManager` class only had `connect_signal()` with no way to disconnect. Since callbacks are bound methods holding references to action objects, those objects were never garbage collected as pages changed.

## Test plan
- [ ] Run StreamController for extended period and monitor memory usage
- [ ] Verify memory stays stable when switching pages repeatedly

🤖 Generated with [Claude Code](https://claude.com/claude-code)