### PR TITLE
Fix Import Warnings

### DIFF
--- a/autostart.py
+++ b/autostart.py
@@ -87,6 +87,7 @@ def setup_autostart_flatpak(enable: bool = True):
 def setup_autostart_desktop_entry(enable: bool = True, native: bool = False):
     log.info("Setting up autostart using desktop entry")
 
+    import globals as gl
 
     xdg_config_home = os.path.join(os.environ.get("HOME"), ".config")
     AUTOSTART_DIR = os.path.join(xdg_config_home, "autostart")

--- a/src/backend/DeckManagement/HelperMethods.py
+++ b/src/backend/DeckManagement/HelperMethods.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 from PIL import Image
 
 import gi
+gi.require_version("Gdk", "4.0")
 from gi.repository import Gdk, Pango
 
 # Import globals


### PR DESCRIPTION
### Summary
This PR fixes two import-related warnings in the codebase:

1. **autostart.py**: Added missing `import globals as gl` to resolve an undefined variable warning
2. **HelperMethods.py**: Added `gi.require_version("Gdk", "4.0")` to properly initialize the Gdk binding before import

### Changes
- **autostart.py**: Added `import globals as gl` in `setup_autostart_desktop_entry()` function
- **src/backend/DeckManagement/HelperMethods.py**: Added `gi.require_version("Gdk", "4.0")` before importing Gdk

### Testing
- Both changes resolve warnings without affecting functionality
- No behavioral changes to the application
- All existing functionality remains intact

### Type
- Bug fix (warning resolution)

These are minimal, targeted fixes that clean up build while maintaining all existing functionality.