### PR TITLE
Window Grabber Supported Sway Environments

### DIFF
--- a/src/backend/WindowGrabber/WindowGrabber.py
+++ b/src/backend/WindowGrabber/WindowGrabber.py
@@ -33,7 +33,7 @@ from src.backend.WindowGrabber.Integrations.KDE import KDE
 
 class WindowGrabber:
     def __init__(self):
-        self.SUPPORTED_ENVS = ["hyprland", "gnome", "sway", "x11", "kde"]
+        self.SUPPORTED_ENVS = ["hyprland", "gnome", "sway", "sway:wlroots", "sway:wlroots:swayfx", "scroll:wlroots", "x11", "kde"]
 
         self.integration: Integration = None
         self.init_integration()
@@ -66,7 +66,7 @@ class WindowGrabber:
             self.integration = Hyprland(self)
         elif self.environment == "gnome":
             self.integration = Gnome(self)
-        elif self.environment == "sway":
+        elif "sway" in self.environment or self.environment == "scroll:wlroots":
             self.integration = Sway(self)
         elif self.server == "x11":
             self.integration = X11(self)

--- a/src/backend/WindowGrabber/WindowGrabber.py
+++ b/src/backend/WindowGrabber/WindowGrabber.py
@@ -33,7 +33,7 @@ from src.backend.WindowGrabber.Integrations.KDE import KDE
 
 class WindowGrabber:
     def __init__(self):
-        self.SUPPORTED_ENVS = ["hyprland", "gnome", "sway", "sway:wlroots", "sway:wlroots:swayfx", "scroll:wlroots", "x11", "kde"]
+        self.SUPPORTED_ENVS = ["hyprland", "gnome", "sway", "sway:wlroots", "sway:wlroots:swayfx", "x11", "kde"]
 
         self.integration: Integration = None
         self.init_integration()
@@ -66,7 +66,7 @@ class WindowGrabber:
             self.integration = Hyprland(self)
         elif self.environment == "gnome":
             self.integration = Gnome(self)
-        elif "sway" in self.environment or self.environment == "scroll:wlroots":
+        elif "sway" in self.environment:
             self.integration = Sway(self)
         elif self.server == "x11":
             self.integration = X11(self)


### PR DESCRIPTION
I noticed recently that Sway/SwayFX returns different values for XDG_CURRENT_DESKTOP now vs when the integration was first added. This just adds in 2 supported envs for Sway so that it covers Sway itself as well as the popular SwayFX fork. Left the original sway option just in case it is still used or set manually.