### PR TITLE
Fix Font Style Persistence Issue

### DIFF
--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -2183,6 +2183,8 @@ class ControllerKey(ControllerInput):
                         text=state_dict["labels"][label].get("text"),
                         font_size=state_dict["labels"][label].get("font-size"),
                         font_name=state_dict["labels"][label].get("font-family"),
+                        font_weight=state_dict["labels"][label].get("font-weight"),
+                        style=state_dict["labels"][label].get("style"),
                         color=state_dict["labels"][label].get("color"),
                         outline_width=state_dict["labels"][label].get("outline_width"),
                         outline_color=state_dict["labels"][label].get("outline_color"),
@@ -2492,6 +2494,8 @@ class ControllerDial(ControllerInput):
                     text=state_dict["labels"][label].get("text"),
                     font_size=state_dict["labels"][label].get("font-size"),
                     font_name=state_dict["labels"][label].get("font-family"),
+                    font_weight=state_dict["labels"][label].get("font-weight"),
+                    style=state_dict["labels"][label].get("style"),
                     color=state_dict["labels"][label].get("color"),
                     alignment=state_dict["labels"][label].get("alignment"),
                 )

--- a/src/backend/DeckManagement/Subclasses/KeyLabel.py
+++ b/src/backend/DeckManagement/Subclasses/KeyLabel.py
@@ -58,6 +58,7 @@ class KeyLabel:
         self.font_size = None
         self.font_name = None
         self.font_weight = None
+        self.style = None
         self.color = None
         self.outline_width = None
         self.outline_color = None


### PR DESCRIPTION
Resolves: https://github.com/StreamController/StreamController/issues/504

## Problem
Font styles (bold/italic) were not persisting after:
- Reloading the application 
- Moving labels to new buttons
- Using the reset functionality

## Root Cause
The issue was caused by missing `font_weight` and `style` parameters when loading [KeyLabel](cci:2://file:///home/bobby/git/StreamController/src/backend/DeckManagement/Subclasses/KeyLabel.py:25:0-67:71) objects from JSON data. When labels were loaded from the page configuration, these font styling attributes were not being properly restored, causing them to revert to default values.

## Solution
Added the missing font styling parameters to all [KeyLabel](cci:2://file:///home/bobby/git/StreamController/src/backend/DeckManagement/Subclasses/KeyLabel.py:25:0-67:71) creation points:

1. **Fixed [clear_values()](cci:1://file:///home/bobby/git/StreamController/src/backend/DeckManagement/Subclasses/KeyLabel.py:55:4-64:29) method** in [KeyLabel.py](cci:7://file:///home/bobby/git/StreamController/src/backend/DeckManagement/Subclasses/KeyLabel.py:0:0-0:0):
   - Added `self.style = None` to properly clear the font style when resetting

2. **Fixed [load_from_input_dict()](cci:1://file:///home/bobby/git/StreamController/src/backend/DeckManagement/DeckController.py:19:4-23:52) for keys** in [DeckController.py](cci:7://file:///home/bobby/git/StreamController/src/backend/DeckManagement/DeckController.py:0:0-0:0):
   - Added `font_weight=state_dict["labels"][label].get("font-weight")`
   - Added `style=state_dict["labels"][label].get("style")`

3. **Fixed [load_from_input_dict()](cci:1://file:///home/bobby/git/StreamController/src/backend/DeckManagement/DeckController.py:19:4-23:52) for dials** in [DeckController.py](cci:7://file:///home/bobby/git/StreamController/src/backend/DeckManagement/DeckController.py:0:0-0:0):
   - Added the same missing parameters for dial label loading

## Files Changed
- [src/backend/DeckManagement/Subclasses/KeyLabel.py](cci:7://file:///home/bobby/git/StreamController/src/backend/DeckManagement/Subclasses/KeyLabel.py:0:0-0:0)
- [src/backend/DeckManagement/DeckController.py](cci:7://file:///home/bobby/git/StreamController/src/backend/DeckManagement/DeckController.py:0:0-0:0)

## Testing
The fix ensures that:
- ✅ Font styles (bold/italic) persist after app reload
- ✅ Font styles transfer correctly when moving labels between buttons  
- ✅ Font styles are properly cleared when using reset functionality
- ✅ All font attributes (family, size, weight, style) are consistently loaded and saved

## Technical Details
The [KeyLabel](cci:2://file:///home/bobby/git/StreamController/src/backend/DeckManagement/Subclasses/KeyLabel.py:25:0-67:71) dataclass already had the `style` field defined, but it wasn't being populated during the JSON loading process. This meant that even though the font style was correctly saved to the page configuration, it was lost when the application restarted or when labels were moved between different inputs.

[Screencast_20260106_115929.webm](https://github.com/user-attachments/assets/2ebbe3da-f3b1-4a96-b925-eeb6c7c71649)
