### PR TITLE
Feat(DialBox): Add software knob interaction and context menu support

### DIFF
--- a/src/windows/mainWindow/DeckPlus/DialBox.py
+++ b/src/windows/mainWindow/DeckPlus/DialBox.py
@@ -15,6 +15,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 # Import gtk modules
 import threading
 import time
+import math
 import gi
 
 from StreamDeck.Devices.StreamDeck import DialEventType, TouchscreenEventType
@@ -75,7 +76,7 @@ class Dial(Gtk.Frame):
 
         self.click_ctrl = Gtk.GestureClick().new()
         self.click_ctrl.connect("pressed", self.on_click)
-        # self.click_ctrl.set_button(4)
+        self.click_ctrl.set_button(0)
         self.image.add_controller(self.click_ctrl)
 
         self.scroll_ctrl = Gtk.EventControllerScroll()
@@ -98,29 +99,92 @@ class Dial(Gtk.Frame):
         self.image.set_focusable(True)
 
         self.last_scroll = None
+        
+        # Software knob properties
+        self.knob_rotation = 0  # Current rotation angle in degrees
+        self.knob_dragging = False
+        self.knob_last_angle = 0
+        self.knob_start_y = 0
+        self.knob_sensitivity = 2.0  # Degrees per pixel of vertical drag
+        
+        # Add drag controller for software knob
+        self.drag_controller = Gtk.GestureDrag()
+        self.drag_controller.connect("drag-begin", self.on_knob_drag_begin)
+        self.drag_controller.connect("drag-update", self.on_knob_drag_update)
+        self.drag_controller.connect("drag-end", self.on_knob_drag_end)
+        self.image.add_controller(self.drag_controller)
+        
+        # Set cursor for drag interaction
+        self.image.set_cursor(Gdk.Cursor.new_from_name("grab"))
 
 
         ## Actions
         self.action_group = Gio.SimpleActionGroup()
         self.insert_action_group("dial", self.action_group)
 
+        self.turn_left_action = Gio.SimpleAction.new("turn-left", None)
+        self.turn_right_action = Gio.SimpleAction.new("turn-right", None)
+        self.copy_action = Gio.SimpleAction.new("copy", None)
+        self.cut_action = Gio.SimpleAction.new("cut", None)
+        self.paste_action = Gio.SimpleAction.new("paste", None)
         self.remove_action = Gio.SimpleAction.new("remove", None)
+        self.update_action = Gio.SimpleAction.new("update", None)
+
+        self.turn_left_action.connect("activate", self.on_turn_left)
+        self.turn_right_action.connect("activate", self.on_turn_right)
+        self.copy_action.connect("activate", self.on_copy)
+        self.cut_action.connect("activate", self.on_cut)
+        self.paste_action.connect("activate", self.on_paste)
         self.remove_action.connect("activate", self.on_remove)
+        self.update_action.connect("activate", self.on_update)
+
+        self.action_group.add_action(self.turn_left_action)
+        self.action_group.add_action(self.turn_right_action)
+        self.action_group.add_action(self.copy_action)
+        self.action_group.add_action(self.cut_action)
+        self.action_group.add_action(self.paste_action)
         self.action_group.add_action(self.remove_action)
+        self.action_group.add_action(self.update_action)
 
         ## Shortcuts
         self.shortcut_controller = Gtk.ShortcutController()
         self.add_controller(self.shortcut_controller)
 
+        turn_left_shortcut_action = Gtk.CallbackAction.new(self.on_turn_left)
+        turn_right_shortcut_action = Gtk.CallbackAction.new(self.on_turn_right)
+        copy_shortcut_action = Gtk.CallbackAction.new(self.on_copy)
+        cut_shortcut_action = Gtk.CallbackAction.new(self.on_cut)
+        paste_shortcut_action = Gtk.CallbackAction.new(self.on_paste)
         remove_shortcut_action = Gtk.CallbackAction.new(self.on_remove)
+        update_shortcut_action = Gtk.CallbackAction.new(self.on_update)
 
+        self.turn_left_shortcut = Gtk.Shortcut.new(Gtk.ShortcutTrigger.parse_string("Left"), turn_left_shortcut_action)
+        self.turn_right_shortcut = Gtk.Shortcut.new(Gtk.ShortcutTrigger.parse_string("Right"), turn_right_shortcut_action)
+        self.copy_shortcut = Gtk.Shortcut.new(Gtk.ShortcutTrigger.parse_string("<Primary>c"), copy_shortcut_action)
+        self.cut_shortcut = Gtk.Shortcut.new(Gtk.ShortcutTrigger.parse_string("<Primary>x"), cut_shortcut_action)
+        self.paste_shortcut = Gtk.Shortcut.new(Gtk.ShortcutTrigger.parse_string("<Primary>v"), paste_shortcut_action)
         self.remove_shortcut = Gtk.Shortcut.new(Gtk.ShortcutTrigger.parse_string("Delete"), remove_shortcut_action)
+        self.update_shortcut = Gtk.Shortcut.new(Gtk.ShortcutTrigger.parse_string("F5"), update_shortcut_action)
+
+        self.shortcut_controller.add_shortcut(self.turn_left_shortcut)
+        self.shortcut_controller.add_shortcut(self.turn_right_shortcut)
+        self.shortcut_controller.add_shortcut(self.copy_shortcut)
+        self.shortcut_controller.add_shortcut(self.cut_shortcut)
+        self.shortcut_controller.add_shortcut(self.paste_shortcut)
         self.shortcut_controller.add_shortcut(self.remove_shortcut)
+        self.shortcut_controller.add_shortcut(self.update_shortcut)
 
 
 
     def on_key(self, controller, keyval, keycode, state):
-        return
+        # Handle arrow keys for software knob turning when dial is focused
+        if keyval == Gdk.KEY_Left:
+            self.on_turn_left()
+            return True
+        elif keyval == Gdk.KEY_Right:
+            self.on_turn_right()
+            return True
+        return False
 
     def on_scroll(self, gesture, dx, dy):
         if self.last_scroll:
@@ -167,6 +231,13 @@ class Dial(Gtk.Frame):
                 GLib.timeout_add(100, controller.event_callback, self.identifier, DialEventType.PUSH, 0)
             pass
 
+        elif gesture.get_current_button() == 3 and n_press == 1:
+            # Single right click
+            # Open context menu
+            popover = DialContextMenu(self)
+            popover.on_open()
+            popover.popup()
+
         else:
             pass
 
@@ -182,6 +253,127 @@ class Dial(Gtk.Frame):
         else:
             self.set_css_classes(["dial-frame", "dial-frame-hidden"])
             self.dial_box.page_settings_page.deck_config.active_widget = None
+
+    def on_knob_drag_begin(self, gesture, start_x, start_y):
+        """Initialize drag state when user starts dragging the knob"""
+        self.knob_dragging = True
+        self.knob_start_y = start_y
+        # Calculate initial angle based on drag position relative to center
+        widget_size = min(self.get_width(), self.get_height())
+        if widget_size > 0:
+            center_x = widget_size / 2
+            center_y = widget_size / 2
+            self.knob_last_angle = math.degrees(math.atan2(start_y - center_y, start_x - center_x))
+        else:
+            self.knob_last_angle = 0
+        
+        # Change cursor to grabbing
+        self.image.set_cursor(Gdk.Cursor.new_from_name("grabbing"))
+
+    def on_knob_drag_update(self, gesture, offset_x, offset_y):
+        """Handle drag updates to turn the knob"""
+        if not self.knob_dragging:
+            return
+            
+        # Get the start point correctly for GTK4
+        start_point = gesture.get_start_point()
+        start_x = start_point.x
+        start_y = start_point.y
+        current_x = start_x + offset_x
+        current_y = start_y + offset_y
+        
+        # Calculate angle based on current position relative to center
+        widget_size = min(self.get_width(), self.get_height())
+        if widget_size > 0:
+            center_x = widget_size / 2
+            center_y = widget_size / 2
+            current_angle = math.degrees(math.atan2(current_y - center_y, current_x - center_x))
+            
+            # Calculate angle difference
+            angle_diff = current_angle - self.knob_last_angle
+            
+            # Handle angle wrap-around
+            if angle_diff > 180:
+                angle_diff -= 360
+            elif angle_diff < -180:
+                angle_diff += 360
+            
+            # Update rotation
+            self.knob_rotation += angle_diff
+            self.knob_rotation = self.knob_rotation % 360  # Keep within 0-360
+            
+            # Trigger dial turn events based on rotation
+            if abs(angle_diff) > 5:  # Threshold to prevent too many events
+                steps = int(abs(angle_diff) / 10)  # One step per 10 degrees
+                direction = 1 if angle_diff > 0 else -1
+                
+                for _ in range(steps):
+                    self.on_turn_right() if direction > 0 else self.on_turn_left()
+                
+                self.knob_last_angle = current_angle
+
+    def on_knob_drag_end(self, gesture, offset_x, offset_y):
+        """Clean up drag state when user stops dragging"""
+        self.knob_dragging = False
+        # Reset cursor to grab
+        self.image.set_cursor(Gdk.Cursor.new_from_name("grab"))
+
+    def on_turn_left(self, *args):
+        """Turn the knob one step to the left in software"""
+        controller = gl.app.main_win.get_active_controller()
+        if controller is not None:
+            controller.event_callback(self.identifier, DialEventType.TURN, -1)
+
+    def on_turn_right(self, *args):
+        """Turn the knob one step to the right in software"""
+        controller = gl.app.main_win.get_active_controller()
+        if controller is not None:
+            controller.event_callback(self.identifier, DialEventType.TURN, 1)
+
+    def on_copy(self, *args):
+        controller = gl.app.main_win.get_active_controller()
+        if controller is None:
+            return
+        
+        active_page = controller.active_page
+        if active_page is None:
+            return
+        
+        dial_dict = active_page.dict.get(self.identifier.input_type, {}).get(self.identifier.json_identifier, {})
+        gl.app.main_win.key_dict = dial_dict
+        content = Gdk.ContentProvider.new_for_value(dial_dict)
+        gl.app.main_win.key_clipboard.set_content(content)
+
+    def on_cut(self, *args):
+        self.on_copy()
+        self.on_remove()
+
+    def on_paste(self, *args):
+        # Check if clipboard is from this StreamController
+        if not gl.app.main_win.key_clipboard.is_local() and False:  # TODO: Rely on system keyboard - Enabling this will cause copy/paste problems on KDE/Wayland
+            #TODO: Use read_value_async to read it instead - This is more like a temporary hack
+            return
+        
+        # Remove the old action objects - useful in case the same action base is used across multiple actions because we would have no way to differentiate them
+        self.on_remove()
+        
+        controller = gl.app.main_win.get_active_controller()
+        if controller is None:
+            return
+        
+        active_page = controller.active_page
+        if active_page is None:
+            return
+        
+        active_page.dict.setdefault(self.identifier.input_type, {})
+        active_page.dict[self.identifier.input_type].setdefault(self.identifier.json_identifier, {})
+        active_page.dict[self.identifier.input_type][self.identifier.json_identifier] = gl.app.main_win.key_dict
+        active_page.reload_similar_pages(identifier=self.identifier, reload_self=True)
+
+        # Reload ui
+        dial = controller.get_input(self.identifier)
+        if dial is not None:
+            gl.app.main_win.sidebar.load_for_identifier(self.identifier, dial.state)
 
     def on_remove(self, *args) -> None:
         controller = gl.app.main_win.get_active_controller()
@@ -203,5 +395,51 @@ class Dial(Gtk.Frame):
 
         active_page.reload_similar_pages(identifier=self.identifier, reload_self=True)
 
-        # Reload ui
-        gl.app.main_win.sidebar.load_for_identifier(self.identifier, dial.state)
+    def on_update(self, *args, **kwargs):
+        controller = gl.app.main_win.get_active_controller()
+        if controller is None:
+            return
+        
+        dial = controller.get_input(self.identifier)
+        if dial is None:
+            return
+            
+        # Reload the dial's current state
+        dial.update()
+
+
+class DialContextMenu(Gtk.PopoverMenu):
+    def __init__(self, dial: Dial, **kwargs):
+        super().__init__(**kwargs)
+        self.dial = dial
+        self.build()
+
+        self.connect("closed", self.on_close)
+
+    def build(self):
+        self.set_parent(self.dial)
+        self.set_has_arrow(False)
+
+        self.main_menu = Gio.Menu.new()
+
+        self.copy_paste_menu = Gio.Menu.new()
+        self.remove_menu = Gio.Menu.new()
+
+        # Add actions to menus
+        self.copy_paste_menu.append("Copy", "dial.copy")
+        self.copy_paste_menu.append("Cut", "dial.cut")
+        self.copy_paste_menu.append("Paste", "dial.paste")
+        self.remove_menu.append("Remove", "dial.remove")
+        self.remove_menu.append("Update", "dial.update")
+
+        # Add sections to menu
+        self.main_menu.append_section(None, self.copy_paste_menu)
+        self.main_menu.append_section(None, self.remove_menu)
+
+        self.set_menu_model(self.main_menu)
+
+    def on_close(self, *args, **kwargs):
+        return
+    
+    def on_open(self, *args, **kwargs):
+        return

--- a/src/windows/mainWindow/DeckPlus/DialBox.py
+++ b/src/windows/mainWindow/DeckPlus/DialBox.py
@@ -235,7 +235,6 @@ class Dial(Gtk.Frame):
             # Single right click
             # Open context menu
             popover = DialContextMenu(self)
-            popover.on_open()
             popover.popup()
 
         else:
@@ -417,7 +416,6 @@ class DialContextMenu(Gtk.PopoverMenu):
         self.connect("closed", self.on_close)
 
     def build(self):
-        self.set_parent(self.dial)
         self.set_has_arrow(False)
 
         self.main_menu = Gio.Menu.new()
@@ -437,6 +435,12 @@ class DialContextMenu(Gtk.PopoverMenu):
         self.main_menu.append_section(None, self.remove_menu)
 
         self.set_menu_model(self.main_menu)
+
+    def popup(self):
+        """Override popup to set parent just before showing"""
+        if self.dial and not self.get_parent():
+            self.set_parent(self.dial)
+        super().popup()
 
     def on_close(self, *args, **kwargs):
         return


### PR DESCRIPTION
Resolves: #338 

## Summary
This PR adds comprehensive software control for dials in the StreamController UI, including drag-to-turn functionality, keyboard shortcuts, and a context menu for dial management.

## Changes
- **Drag-to-turn functionality**: Users can now click and drag on dials to turn them naturally with circular gesture detection
- **Keyboard shortcuts**: Left/Right arrow keys turn dials when focused
- **Context menu**: Right-click menu with copy, cut, paste, remove, and update actions
- **Visual feedback**: Cursor changes (grab/grabbing) to indicate interactivity
- **Angle-based rotation**: Mathematical calculations for natural knob turning behavior

## Technical Details
- Added `Gtk.GestureDrag` controller for drag interactions
- Implemented angle calculations using `math.atan2()` for circular motion detection
- Added Gio actions and keyboard shortcuts for software control
- Created `DialContextMenu` class with proper menu structure
- Integrated with existing dial event system using `DialEventType.TURN`

## Files Modified
- `src/windows/mainWindow/DeckPlus/DialBox.py`: Added 242 lines of new functionality

## Testing
- Verified drag-to-turn works with circular gestures
- Confirmed keyboard shortcuts trigger proper dial events
- Tested context menu actions (copy, cut, paste, remove, update)
- No CSS warnings or runtime errors

## Usage
1. **Drag to turn**: Click and drag on any dial in a circular motion
2. **Keyboard control**: Focus a dial and use Left/Right arrow keys
3. **Context menu**: Right-click for dial management options

This enhancement makes the StreamController much more user-friendly for testing and configuration by providing intuitive software control over dial inputs.


[Screencast_20260106_153830.webm](https://github.com/user-attachments/assets/fc480f7d-a663-441b-8de8-52986b1ade11)
