### PR TITLE
[Bug Fix]: Stabilize resume by keeping controllers alive during transient HID errors

### DIFF
--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -93,16 +93,25 @@ class MediaPlayerSetTouchscreenImageTask:
             self.deck_controller.deck.set_touchscreen_image(self.native_image, x_pos=0, y_pos=0, width=touchscreen_size[0], height=touchscreen_size[1]) # Maybe avoid to always merge the dial images before applying it
             self.native_image = None
             del self.native_image
-            MediaPlayerSetTouchscreenImageTask.n_failed_in_row = 0
+            MediaPlayerSetTouchscreenImageTask.n_failed_in_row[self.deck_controller.serial_number()] = 0
         except StreamDeck.TransportError as e:
             log.error(f"Failed to set deck touchscreen image. Error: {e}")
-            MediaPlayerSetTouchscreenImageTask.n_failed_in_row += 1
-            if MediaPlayerSetTouchscreenImageTask.n_failed_in_row > 5:
-                log.debug(
-                    f"Failed to set touchscreen image for 5 times in a row for deck "
-                    f"{self.deck_controller.serial_number()}. Keeping controller alive"
-                )
+
+            beta_resume = gl.settings_manager.get_app_settings().get("system", {}).get("beta-resume-mode", True)
+            if beta_resume:
+                # Transient HID failures are expected right after resume - keep the controller alive and retry
                 return
+
+            serial = self.deck_controller.serial_number()
+            MediaPlayerSetTouchscreenImageTask.n_failed_in_row[serial] = MediaPlayerSetTouchscreenImageTask.n_failed_in_row.get(serial, 0) + 1
+            if MediaPlayerSetTouchscreenImageTask.n_failed_in_row[serial] > 10:
+                log.debug(f"Failed to set touchscreen image for 10 times in a row for deck {serial}. Removing controller")
+
+                self.deck_controller.deck.close()
+                self.deck_controller.media_player.running = False # Set stop flag - otherwise remove_controller will wait until this task is done, which it never will because it waits
+                gl.deck_manager.remove_controller(self.deck_controller)
+
+                gl.deck_manager.connect_new_decks()
 
 @dataclass
 class MediaPlayerSetImageTask:


### PR DESCRIPTION
### Background
After suspend/resume, Stream Deck HID handles can temporarily fail (“No HID device”), even with the `Use new resume mode (beta)` flag turned ON. The previous
behavior removed controllers after repeated touchscreen transport errors, which triggered re-enumeration against
devices that were not yet ready and led to crashes/races.

### Changes:

1. Keep controllers alive on repeated touchscreen transport errors instead of removing/reconnecting.
2. Guard update_all_inputs() and tick_actions() when active_page is None to avoid resume-time crashes.


### Result
The app now survives transient HID failures and recovers without process restarts or race-condition
exceptions.