### PR TITLE
fix: properly close event loops in EventHolder and Observer

### DIFF
--- a/src/backend/PluginManager/EventHolder.py
+++ b/src/backend/PluginManager/EventHolder.py
@@ -29,7 +29,11 @@ class EventHolder:
         # FIX: This can throw an error, if this happens apply the fix from Observer.py
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        loop.run_until_complete(self._run_event(self.event_id, *args, **kwargs))
+        try:
+            loop.run_until_complete(self._run_event(self.event_id, *args, **kwargs))
+        finally:
+            loop.close()
+
 
     async def _run_event(self, *args, **kwargs):
         coroutines = [self._ensure_coroutine(observer, *args, **kwargs) for observer in self.observers]

--- a/src/backend/PluginManager/PluginSettings/Observer.py
+++ b/src/backend/PluginManager/PluginSettings/Observer.py
@@ -30,6 +30,8 @@ class Observer:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             loop.run_until_complete(self._notify(*args, **kwargs))
+        finally:
+            loop.close()
 
     async def _notify(self, *args, **kwargs):
         coroutines = [self._ensure_coroutine(observer, *args, **kwargs) for observer in self.observers]


### PR DESCRIPTION
## Summary

- Add try-finally blocks to ensure event loops are properly closed
- Fixes resource leak when creating new event loops in EventHolder
  and Observer
- Prevents potential memory/resource issues from unclosed loops

## Changes

- `EventHolder.py`: Wrap `run_until_complete` in try-finally to
  close loop
- `Observer.py`: Add finally block to close event loop after notify

## Why

When creating new event loops with `asyncio.new_event_loop()`, they
must be explicitly closed to prevent resource leaks. The comment in
EventHolder.py referenced applying a fix from Observer.py, but
Observer.py also needed the same fix applied.