### PR TITLE
fix: kdotools search needs a search term

### DIFF
--- a/src/backend/WindowGrabber/Integrations/KDE.py
+++ b/src/backend/WindowGrabber/Integrations/KDE.py
@@ -79,7 +79,7 @@ class KDE(Integration):
         windows: list[Window] = []
 
         try:
-            root = self._run_command(["kdotool", "search"])
+            root = self._run_command(["kdotool", "search", "."])
             if root is None:
                 return []
             stdout, _ = root.communicate()


### PR DESCRIPTION
Calling just "kdotool search" fails with "Error: missing argument". According to the documentation it expects a search term. The term [can be a regular expression](https://github.com/jinliu/kdotool/blob/master/src/templates.rs#L92C11-L92C13), hence we use "." to search for any character as we want to list all windows.