### PR TITLE
Adding support for dials that don't have an associated touchscreen

### DIFF
--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -335,6 +335,7 @@ class DeckController:
         self.key_spacing = (36, 36)
 
         if isinstance(self.deck, StreamDeckPlus) or (isinstance(self.deck, FakeDeck) and self.deck.key_layout() == [2, 4]):
+            log.error("Deck recognized as StreamDeckPlus")
             self.key_spacing = (52, 36)
 
         # Tasks
@@ -2545,7 +2546,8 @@ class ControllerDial(ControllerInput):
             self.update()
 
     def update(self):
-        self.get_touch_screen().update()
+        if self.deck_controller.deck.is_touch():
+            self.get_touch_screen().update()
 
     def get_active_state(self) -> "ControllerDialState":
         return super().get_active_state()
@@ -2560,7 +2562,9 @@ class ControllerDial(ControllerInput):
         self.update()
 
     def get_image_size(self) -> tuple[int, int]:
-        return self.get_touch_screen().get_dial_image_area_size()
+        if self.deck_controller.deck.is_touch():
+            return self.get_touch_screen().get_dial_image_area_size()
+        return (0, 0)
     
 
 class ControllerTouchScreenState(ControllerInputState):

--- a/src/windows/mainWindow/DeckPlus/DialBox.py
+++ b/src/windows/mainWindow/DeckPlus/DialBox.py
@@ -154,8 +154,9 @@ class Dial(Gtk.Frame):
 
             gl.app.main_win.sidebar.load_for_dial(self.identifier, state)
 
-            dial_image = dial.get_active_state().get_rendered_touch_image()
-            gl.app.main_win.sidebar.key_editor.icon_selector.set_image(dial_image)
+            if self.dial_box.deck_controller.deck.is_touch():
+                dial_image = dial.get_active_state().get_rendered_touch_image()
+                gl.app.main_win.sidebar.key_editor.icon_selector.set_image(dial_image)
 
         elif gesture.get_current_button() == 1 and n_press == 2:
             # Double left click


### PR DESCRIPTION
Adding support for dials in a DialBox that don't have a touch screen to avoid error messages an breaking plugins when testing new devices. Separate PR will be created to handle custom layouts, hopefully in a sustainable manner.