### PR TITLE
Fix tray icon on KDE/AUR and deck preview not updating

### DIFF
--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -432,6 +432,7 @@ class DeckController:
         for t in self.inputs:
             for i in self.inputs[t]:
                 i.update()
+        GLib.idle_add(lambda: (lambda g: g.load_from_changes() if g else None)(self.get_own_key_grid()))
         log.debug(f"Updating all inputs took {time.time() - start} seconds")
 
     def event_callback(self, ident: InputIdentifier, *args, **kwargs):
@@ -2266,17 +2267,7 @@ class ControllerKey(ControllerInput):
     def set_ui_key_image(self, image: Image.Image) -> None:
         if image is None:
             return
-        
-        x, y = ControllerKey.Index_To_Coords(self.deck_controller.deck, self.index)
-
-        if self.deck_controller.get_own_key_grid() is None or not gl.app.main_win.get_mapped():
-            # Save to use later
-            self.deck_controller.ui_image_changes_while_hidden[self.identifier] = image # The ui key coords are in reverse order
-        else:
-            try:
-                self.deck_controller.get_own_key_grid().buttons[x][y].set_image(image)
-            except:
-                print(f"Failed to set ui key image for {self.identifier}")
+        self.deck_controller.ui_image_changes_while_hidden[self.identifier] = image
         
     def get_own_ui_key(self) -> KeyButton:
         x, y = ControllerKey.Index_To_Coords(self.deck_controller.deck, self.index)

--- a/src/tray.py
+++ b/src/tray.py
@@ -3,6 +3,11 @@ from loguru import logger as log
 import globals as gl
 from src.backend.trayicon import DBusTrayIcon, DBusMenu
 
+import gi
+gi.require_version("Gtk", "4.0")
+gi.require_version("Gdk", "4.0")
+from gi.repository import Gtk, Gdk
+
 class TrayIcon(DBusTrayIcon):
     MenuPath = "/com/core447/StreamController/Menu"
     IndicatorPath = "/org/ayatana/NotificationItem/com_core447_StreamController_TrayIcon"
@@ -20,7 +25,7 @@ class TrayIcon(DBusTrayIcon):
         self.menu.add_menu_item(6, menu_type="separator")
         self.menu.add_menu_item(7, "Quit", callback=self.on_quit)
         super().__init__(self.menu, self.MenuPath, self.IndicatorPath, self.AppId, "StreamController")
-        self.set_icon("com.core447.StreamController")
+        self.set_icon("com.core447.StreamController", "")
         self.set_tooltip("StreamController")
         self.set_label("StreamController")
 
@@ -33,11 +38,24 @@ class TrayIcon(DBusTrayIcon):
 
     @log.catch
     def initialize(self, main_win):
+        if gl.IS_MAC:
+            return
         self.main_win = main_win
         self.show_about_action = main_win.menu_button.open_about_action
         self.show_store_action = main_win.menu_button.open_store_action
         self.show_settings_action = main_win.menu_button.open_settings_action
         self.quit_app_action = main_win.menu_button.quit_action
+        assets = os.path.join(gl.top_level_dir, "Assets", "icons")
+        if os.path.isdir(os.path.join(assets, "hicolor")):
+            self.set_icon("com.core447.StreamController", os.path.abspath(assets))
+        else:
+            name = "com.core447.StreamController"
+            display = Gdk.Display.get_default()
+            if display:
+                theme = Gtk.IconTheme.get_for_display(display)
+                if theme.has_icon("streamcontroller") and not theme.has_icon(name):
+                    name = "streamcontroller"
+            self.set_icon(name, "")
         app_settings = gl.settings_manager.get_app_settings()
         show_now = app_settings.get("ui",{}).get("tray-icon", True)
         if show_now:
@@ -71,35 +89,3 @@ class TrayIcon(DBusTrayIcon):
     @log.catch
     def on_quit(self):
         self.quit_app_action.activate()
-
-
-
-# import os
-# os.environ["PYSTRAY_BACKEND"] = "appindicator"
-# # import pystray
-
-# from pystray import _appindicator
-# from PIL import Image
-# from pystray import Menu, MenuItem
-
-# class TrayIcon(_appindicator.Icon):
-#     def __init__(self):
-#         icon_image = Image.open("flatpak/icon_256.png")
-#         menu = Menu(
-#             MenuItem("StreamController", enabled=False, action=None),
-#             MenuItem("Open", self.on_open),
-#             MenuItem("Quit", self.on_quit)
-#         )
-#         super().__init__("StreamController", icon_image, menu=menu, title="StreamController")
-
-#     def on_open(self):
-#         print("Open")
-
-#     def on_quit(self):
-#         print("Quit")
-#         self.stop()  # Stop the icon running when "Quit" is clicked
-
-# if __name__ == "__main__":
-#     # Usage
-#     stream_controller_icon = TrayIcon()
-#     stream_controller_icon.run()


### PR DESCRIPTION
Fixes: https://github.com/StreamController/StreamController/issues/538

1. **Tray icon missing on KDE Plasma (especially AUR)**  
   - App was asking for `com.core447.StreamController` while the AUR package installs `streamcontroller.png`.  
   - **Change:** In `src/tray.py`, resolve icon once in `initialize()`: if running from source, use `Assets/icons` as `IconThemePath`; otherwise use Gtk icon theme and, when only `streamcontroller` exists, use that name so the AUR icon is found.

2. **Deck preview sometimes blank**  
   - `update_all_inputs` runs in a worker thread and was sometimes updating the key grid before it existed or from the wrong thread.  
   - **Change:** In `DeckController`, `set_ui_key_image` only enqueues images in `ui_image_changes_while_hidden`. After each `update_all_inputs` run we schedule `GLib.idle_add` so the key grid’s `load_from_changes()` runs on the main thread and applies the queued images. No GTK calls from the worker thread; one marshal point per batch.

**Files touched:**  
`src/tray.py`, `src/backend/DeckManagement/DeckController.py`, `src/windows/mainWindow/elements/KeyGrid.py` (comment/typo cleanup only).