### PR TITLE
fix: resolve KDE tray icon by passing bundled IconThemePath

### DIFF
--- a/src/tray.py
+++ b/src/tray.py
@@ -20,7 +20,8 @@ class TrayIcon(DBusTrayIcon):
         self.menu.add_menu_item(6, menu_type="separator")
         self.menu.add_menu_item(7, "Quit", callback=self.on_quit)
         super().__init__(self.menu, self.MenuPath, self.IndicatorPath, self.AppId, "StreamController")
-        self.set_icon("com.core447.StreamController")
+        icon_theme_path = os.path.join(gl.MAIN_PATH, "Assets", "icons")
+        self.set_icon("com.core447.StreamController", path=icon_theme_path)
         self.set_tooltip("StreamController")
         self.set_label("StreamController")
 


### PR DESCRIPTION
## Summary

Fixes #538 — the system tray icon is missing on KDE Plasma for non-Flatpak installations (AUR, etc.).

**Root cause:** `src/tray.py` sets the StatusNotifierItem `IconName` to `com.core447.StreamController`, but on non-Flatpak systems the icon is installed as `streamcontroller.png` (not `com.core447.StreamController.png`), so KDE cannot find it in the system icon theme.

**Fix:** The StatusNotifierItem spec provides `IconThemePath` exactly for this case — an additional path the desktop environment should search for icons. The repository already ships the icon correctly named at:
- `Assets/icons/hicolor/48x48/apps/com.core447.StreamController.png`
- `Assets/icons/hicolor/512x512/apps/com.core447.StreamController.png`

`Assets/icons/` is already a valid freedesktop icon theme root. We now pass its absolute path as `IconThemePath`, so KDE always finds the bundled icon regardless of installation method.

**Change:** `src/tray.py` — one additional line to resolve the icon theme path, and pass it to the existing `set_icon()` call which already accepts a `path` parameter.

## Test plan

- [ ] Launch StreamController on KDE Plasma with a non-Flatpak install and confirm the tray icon appears
- [ ] Confirm the tray icon still appears on Flatpak / GNOME installs (no regression)