### PR TITLE
fix: wrap replacement deck in BetterDeck on resume from sleep

### DIFF
--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -290,7 +290,8 @@ class DeckManager:
             new_device = self.get_device_by_serial(deck_controller.serial_number())
             if new_device:
                 log.info(f"Replacing deck")
-                deck_controller.deck = new_device
+                current_rotation = deck_controller.deck.get_rotation()
+                deck_controller.deck = BetterDeck(new_device, current_rotation)
                 deck_controller.update_all_inputs()
 
                 deck_controller.deck.set_key_callback(deck_controller.key_event_callback)


### PR DESCRIPTION
## Summary

Fixes #464 — StreamController becomes non-functional after the laptop resumes from sleep, requiring a manual app restart.

**Root cause:**

`DeckController` stores its device as a `BetterDeck` wrapper (defined in `BetterDeck.py`). `BetterDeck` provides `get_rotation()` and transparent key-index remapping for rotated decks.

On resume, `on_resumed()` calls `get_device_by_serial()` which returns a **raw `StreamDeck` SDK device** (not a `BetterDeck`), then assigns it directly:

```python
deck_controller.deck = new_device  # raw SDK object — no get_rotation()
deck_controller.update_all_inputs()  # crashes immediately
```

`update_all_inputs()` calls `self.deck_controller.deck.get_rotation()` at line 1980/1982 of `DeckController.py`, which fails because the raw SDK object doesn't have that method:

```
AttributeError: 'StreamDeckOriginalV2' object has no attribute 'get_rotation'
```

**Fix:**

Preserve the existing rotation from the old `BetterDeck`, then wrap the new raw device in a fresh `BetterDeck` before assigning it — exactly as `DeckController.__init__` does on first load:

```python
current_rotation = deck_controller.deck.get_rotation()
deck_controller.deck = BetterDeck(new_device, current_rotation)
```

`BetterDeck` is already imported in `DeckManager.py`.

## Test plan

- [ ] Sleep and resume the laptop with a Stream Deck connected — confirm it comes back to life without restarting the app
- [ ] Confirm a rotated deck retains its rotation after resume
- [ ] Confirm normal startup/operation is unaffected