### PR TITLE
fix: StreamDeck UI importer - support v1 flat format 

### DIFF
--- a/src/backend/AssetManagerBackend.py
+++ b/src/backend/AssetManagerBackend.py
@@ -142,10 +142,11 @@ class AssetManagerBackend(list):
             dst_path = os.path.join(gl.DATA_PATH, "Assets", "AssetManager", "Assets", file_name)
         else:
             log.warning(f"File with same name already exists but sha256 does not match, renaming: {asset_path}")
+            original_base, ext = os.path.splitext(os.path.basename(asset_path))
             index = 2
             while file_in_dir(file_name, os.path.join(gl.DATA_PATH, "Assets", "AssetManager", "Assets")):
-                base, ext = os.path.splitext(file_name)
-                file_name = f"{base}-{str(index).zfill(2)}.{ext.replace('.', '')}"
+                file_name = f"{original_base}-{str(index).zfill(2)}{ext}"
+                index += 1
             dst_path = os.path.join(gl.DATA_PATH, "Assets", "AssetManager", "Assets", file_name)
 
         if asset_path == dst_path:

--- a/src/windows/PageManager/Importer/Importer.py
+++ b/src/windows/PageManager/Importer/Importer.py
@@ -13,6 +13,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 # Import gi
+import json
 import os
 import threading
 import gi
@@ -47,8 +48,10 @@ class Importer(Adw.ApplicationWindow):
         self.progess_bar = Gtk.ProgressBar(margin_start=20, margin_end=20, margin_top=20, margin_bottom=20, show_text=True)
         self.main_box.append(self.progess_bar)
 
-    def show_error(self):
-        pass
+    def show_error(self, message: str = "Import failed"):
+        GLib.idle_add(self.progess_bar.set_text, message)
+        GLib.idle_add(self.progess_bar.set_fraction, 0)
+        GLib.timeout_add(3000, self.close)
 
     def import_pages(self, path: str, app: str, on_finished: callable = None) -> None:
         self.progess_bar.set_text("Importing...")
@@ -66,10 +69,13 @@ class Importer(Adw.ApplicationWindow):
     @log.catch
     def import_from_streamdeck_ui(self, path: str, on_finished: callable) -> None:
         if not os.path.exists(path):
-            self.show_error()
+            self.show_error("File not found")
             return
-        if not os.path.splitext(os.path.basename(path))[1] == ".json":
-            self.show_error()
+        try:
+            with open(path) as f:
+                json.load(f)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self.show_error("File is not valid JSON")
             return
 
         ui_importer = StreamDeckUIImporter(path)
@@ -86,10 +92,13 @@ class Importer(Adw.ApplicationWindow):
     @log.catch
     def import_from_streamcontroller(self, path: str, on_finished: callable) -> None:
         if not os.path.exists(path):
-            self.show_error()
+            self.show_error("File not found")
             return
-        if not os.path.splitext(os.path.basename(path))[1] == ".json":
-            self.show_error()
+        try:
+            with open(path) as f:
+                json.load(f)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self.show_error("File is not valid JSON")
             return
 
         ui_importer = StreamControllerImporter(path)

--- a/src/windows/PageManager/Importer/StreamController/StreamController.py
+++ b/src/windows/PageManager/Importer/StreamController/StreamController.py
@@ -20,21 +20,23 @@ class StreamControllerImporter:
         self.json_export_path = json_export_path
 
     
-    def save_json(self, json_path: str, data: dict):
+    def save_json(self, json_path: str, data: dict, _retries: int = 3):
         with open(json_path, "w") as f:
             json.dump(data, f, indent=4)
 
         loaded = None
         try:
-            # Verify data
             with open(json_path) as f:
                 loaded = json.load(f)
         except Exception as e:
             pass
 
         if loaded != data:
-            log.error(f"Failed to save {json_path}, trying again")
-            self.save_json(json_path, data)
+            if _retries > 0:
+                log.error(f"Failed to save {json_path}, trying again ({_retries} retries left)")
+                self.save_json(json_path, data, _retries=_retries - 1)
+            else:
+                log.error(f"Failed to save {json_path} after all retries, giving up")
             
     def perform_import(self):
         with open(self.json_export_path) as f:

--- a/src/windows/PageManager/Importer/StreamDeckUI/StreamDeckUI.py
+++ b/src/windows/PageManager/Importer/StreamDeckUI/StreamDeckUI.py
@@ -31,21 +31,23 @@ class StreamDeckUIImporter:
         x = index % cols
         return f"{x}x{y}"
     
-    def save_json(self, json_path: str, data: dict):
+    def save_json(self, json_path: str, data: dict, _retries: int = 3):
         with open(json_path, "w") as f:
             json.dump(data, f, indent=4)
 
         loaded = None
         try:
-            # Verify data
             with open(json_path) as f:
                 loaded = json.load(f)
         except Exception as e:
             pass
 
         if loaded != data:
-            log.error(f"Failed to save {json_path}, trying again")
-            self.save_json(json_path, data)
+            if _retries > 0:
+                log.error(f"Failed to save {json_path}, trying again ({_retries} retries left)")
+                self.save_json(json_path, data, _retries=_retries - 1)
+            else:
+                log.error(f"Failed to save {json_path} after all retries, giving up")
             
     def get_state_map(self, available_states: list[str]):
         available_states = [int(state) for state in available_states]
@@ -83,33 +85,42 @@ class StreamDeckUIImporter:
                     coords = self.index_to_page_coords(int(button), deck)
                     page["keys"][coords] = {}
 
-                    # Choose first state
-                    states = self.export["state"][deck]["buttons"][page_name][button].get("states", {})
+                    button_data = self.export["state"][deck]["buttons"][page_name][button]
+
+                    # Support both formats: with explicit "states" dict, or
+                    # flat format where properties are directly on the button
+                    if "states" in button_data and button_data["states"]:
+                        states = button_data["states"]
+                    else:
+                        states = {"0": button_data}
+
                     state_map = self.get_state_map(available_states=list(states.keys()))
                     for page_state, export_state in state_map.items():
+                        state_data = states[export_state]
+
                         page["keys"][coords].setdefault("states", {})
                         page["keys"][coords]["states"].setdefault(page_state, {})
 
                         ## Text
-                        font_color_hex = self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("font_color")
+                        font_color_hex = state_data.get("font_color")
                         if font_color_hex in [None, ""]:
                             font_color_hex = "#FFFFFFFF"
                         page["keys"][coords]["states"][page_state]["labels"] = {}
                         page["keys"][coords]["states"][page_state]["labels"]["bottom"] = {
-                            "text": self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("text", None),
+                            "text": state_data.get("text", None),
                             "color": hex_to_rgba255(font_color_hex),
                             "font_size": None,
-                            "font_family": font_family_from_path(self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("font"))
+                            "font_family": font_family_from_path(state_data.get("font"))
                         }
-                        
+
                         page["keys"][coords]["states"][page_state]["background"] = {}
-                        color_hex = self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("background_color")
+                        color_hex = state_data.get("background_color")
                         if color_hex not in [None, ""]:
                             page["keys"][coords]["states"][page_state]["background"]["color"] = hex_to_rgba255(color_hex)
 
                         ## Icon
                         page["keys"][coords]["states"][page_state]["media"] = {}
-                        export_icon = self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("icon")
+                        export_icon = state_data.get("icon")
                         if export_icon not in [None, ""]:
                             if os.path.exists(export_icon):
                                 asset_id = gl.asset_manager_backend.add(asset_path=export_icon)
@@ -122,7 +133,7 @@ class StreamDeckUIImporter:
                         page["keys"][coords]["states"][page_state]["actions"] = []
 
                         # Switch page
-                        export_switch_page = self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("switch_page")
+                        export_switch_page = state_data.get("switch_page")
                         if str(export_switch_page) != str(int(page_name)+1) and export_switch_page not in [0, "0", None, ""]:
                             if export_switch_page not in [None, ""]:
                                 page_path = os.path.join(gl.DATA_PATH, "pages", f"ui_{deck}_{export_switch_page}.json")
@@ -136,12 +147,12 @@ class StreamDeckUIImporter:
                                 page["keys"][coords]["states"][page_state]["actions"].append(action)
 
                         # Hotkey
-                        if self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("keys") not in [None, ""]:
+                        if state_data.get("keys") not in [None, ""]:
                             parsed = ""
                             try:
-                                parsed = parse_keys_as_keycodes(self.export["state"][deck]["buttons"][page_name][button]["states"][export_state]["keys"])[0]
+                                parsed = parse_keys_as_keycodes(state_data["keys"])[0]
                             except Exception as e:
-                                log.error(f"Failed to parse keys: {self.export['state'][deck]['buttons'][page_name][button]['states'][export_state]['keys']}. Error: {e}")
+                                log.error(f"Failed to parse keys: {state_data['keys']}. Error: {e}")
 
                             if parsed not in [None, ""]:
                                 action = {
@@ -159,7 +170,7 @@ class StreamDeckUIImporter:
                                 page["keys"][coords]["states"][page_state]["actions"].append(action)
 
                         # Write text
-                        export_write = self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("write")
+                        export_write = state_data.get("write")
                         if export_write not in [None, ""]:
                             action = {
                                 "id": "com_core447_OSPlugin::WriteText",
@@ -170,7 +181,7 @@ class StreamDeckUIImporter:
                             page["keys"][coords]["states"][page_state]["actions"].append(action)
 
                         # Command
-                        export_command = self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("command")
+                        export_command = state_data.get("command")
                         if export_command not in [None, ""]:
                             action = {
                                 "id": "com_core447_OSPlugin::RunCommand",
@@ -181,7 +192,7 @@ class StreamDeckUIImporter:
                             page["keys"][coords]["states"][page_state]["actions"].append(action)
 
                         # Brightness
-                        export_brightness_change = self.export["state"][deck]["buttons"][page_name][button]["states"][export_state].get("brightness_change")
+                        export_brightness_change = state_data.get("brightness_change")
                         if export_brightness_change not in [None, "", 0]:
                             action = None
                             if export_brightness_change > 0:


### PR DESCRIPTION
## Background

I was migrating from the original [streamdeck-ui](https://github.com/timothycrosley/streamdeck-ui) to StreamController. I know, I didn't even realise I was using the old old one. When importing my `~/.streamdeck_ui.json` backup, the importer window froze at "Importing..." with no error and no way to dismiss it.

The root cause is a format mismatch. The importer expects the `"states"` dict structure introduced in [streamdeck-linux-gui](https://github.com/streamdeck-linux-gui/streamdeck-linux-gui) v4.0.0 (config v2), where button properties are wrapped like:

```json
{"states": {"0": {"text": "Hello", "icon": "..."}}}
```

The original streamdeck-ui (config v1) stores properties flat on the button:

```json
{"text": "Hello", "icon": "..."}
```

With the v1 format, `button.get("states", {})` returns an empty dict so the state iteration loop never executes and every key is written as `{}` - the import "succeeds" but produces empty pages.

I also hit a second issue: my backup file was named `.streamdeck_ui.json.backup.20260301`. The `.json` extension check rejected it silently because `os.path.splitext` sees `.20260301` as the extension, and `show_error()` was a no-op.

While investigating I found two more latent bugs in the same code paths.

## What have I changed?

**1. Support streamdeck-ui v1 flat format** (`StreamDeckUI.py`)

When a button has no `"states"` key (or it's empty), the button data itself is now treated as state `"0"`. This is backward compatible - buttons that have the `"states"` dict still go through the existing code path.

**2. Implement `show_error()` and replace extension check with content validation** (`Importer.py`)

- `show_error()` was an empty no-op method. It now shows the error message in the progress bar and auto-closes after 3 seconds. I'm very happy to retract this if it's controversial(!)
- I've replaced the `.json` extension check with actual JSON parsing, so files with non-standard extensions (like `.json.backup.20260301`) work fine as long as they contain valid JSON.

**3. Fix `copy_asset` filename collision loop** (`AssetManagerBackend.py`)

The `while` loop that renames assets on filename collision never incremented its counter, so it would generate the same candidate filename repeatedly. I've also fixed the filename template which was re-splitting the already-modified name on each iteration, causing cumulative suffixes. I'll happily remove these if it complicates review.

**4. Add retry limit to `save_json`** (`StreamDeckUI.py`, `StreamController.py`)

Both importers have a `save_json` method that recursively retries on verification failure with no limit. I've added a cap of 3 retries.

## Testing

I've manually tested with a real streamdeck-ui v1 config file (6 configured buttons with icons, commands, and labels) and verified that:
- The import completes successfully with pages created containing the correct key data, icons, labels, and actions
- An invalid file shows an error message and the window auto-closes
- The existing `"states"` format still works as before

## Related

- #334 - similar import freeze (different root cause: missing font file, but a couple of puzzled people on there)

Here's my (lightly redacted) config:

[streamdeck_ui.json.backup.sanitized.zip](https://github.com/user-attachments/files/25721488/streamdeck_ui.json.backup.sanitized.zip)


