### PR TITLE
Fix: use correct method name in on_change_state D-Bus handler

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -342,7 +342,7 @@ class App(Adw.Application):
             return
 
         # Find the requested page
-        page_path = gl.page_manager.get_best_page_path_match_from_name(page_name)
+        page_path = gl.page_manager.find_matching_page_path(page_name)
         if page_path is None:
             # Page not found - provide helpful suggestions
             available_pages = [os.path.splitext(os.path.basename(p))[0] for p in gl.page_manager.get_pages()]

--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -522,7 +522,7 @@ class DeckController:
             state = state_request["state"]
             
             # Get the page path for the specified page
-            requested_page_path = gl.page_manager.get_best_page_path_match_from_name(page_name)
+            requested_page_path = gl.page_manager.find_matching_page_path(page_name)
             
             if requested_page_path is None:
                 # Page not found - log available pages


### PR DESCRIPTION
## Summary

The `--change-state` CLI feature (added in #460) calls `gl.page_manager.get_best_page_path_match_from_name()`, but this method does not exist on `PageManagerBackend`. The correct method is `find_matching_page_path()`, which is what `on_change_page` and the `api_page_requests` handler already use correctly.

Two call sites are affected:
- `src/app.py` — `on_change_state` D-Bus handler (used when SC is already running)
- `src/backend/DeckManagement/DeckController.py` — `api_state_requests` handler (used when SC is not running and processes queued requests at startup)

The `AttributeError` is silently swallowed by GTK's action handler, so `--change-state` exits successfully but has no effect.

Fixes #571

## Fix

Replace `get_best_page_path_match_from_name` with `find_matching_page_path` in both call sites.

## Testing

Verified on a live StreamController instance (installed via AUR `streamcontroller-git`):

- **Before fix:** `streamcontroller --change-state AL08L2C53065 Desktop 4,1 1` exits silently with no effect, no log output
- **After fix:** state changes correctly on the physical Stream Deck, log confirms: `Successfully changed state of (4,1) to state 1 on device AL08L2C53065`