### PR TITLE
fix: reduce idle CPU usage from ~25% to ~3%

### DIFF
--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -1189,6 +1189,7 @@ class LabelManager:
         self.page_labels = {}
         self.action_labels = {}
         self.scroll_wait = 25
+        self._has_scroll_labels_cache: bool = None
 
         self.init_labels()
         self.frames: dict[str, dict[str, int]] = {
@@ -1213,6 +1214,7 @@ class LabelManager:
  
     def clear_labels(self):
         self.init_labels()
+        self._has_scroll_labels_cache = None
 
     def set_page_label(self, position: str, label: "KeyLabel", update: bool = True):
         if label is None:
@@ -1220,7 +1222,8 @@ class LabelManager:
             label.clear_values()
         else:
             self.page_labels[position] = label
-        
+
+        self._has_scroll_labels_cache = None
         if update:
             self.update_label(position)
 
@@ -1231,6 +1234,7 @@ class LabelManager:
         else:
             self.action_labels[position] = label
 
+        self._has_scroll_labels_cache = None
         GLib.idle_add(self.update_label_editor)
         if update:
             self.update_label(position)
@@ -1346,12 +1350,17 @@ class LabelManager:
         return self.controller_input.get_image_size()[0]
 
     def get_has_scroll_labels(self) -> bool:
+        if self._has_scroll_labels_cache is not None:
+            return self._has_scroll_labels_cache
+
         labels = self.get_composed_labels()
         for label in labels:
             if labels[label].text is not None and labels[label].text != "":
                 _, _, w, _ = labels[label].get_font().getbbox(labels[label].text)
                 if w > self.get_available_width():
+                    self._has_scroll_labels_cache = True
                     return True
+        self._has_scroll_labels_cache = False
         return False
 
     def add_labels_to_image(self, image: Image.Image) -> Image.Image:

--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -156,6 +156,7 @@ class MediaPlayerThread(threading.Thread):
         self.tasks: list[MediaPlayerTask] = []
         self.image_tasks = {}
         self.touchscreen_task = None
+        self._wake_event = threading.Event()
 
         self.fps: list[float] = []
         self.old_warning_state = False
@@ -172,38 +173,66 @@ class MediaPlayerThread(threading.Thread):
             # self.check_connection()
 
             if not self.pause:
+                has_bg_video = False
+
                 if self.deck_controller.background.video is not None:
                     if self.deck_controller.background.video.page is self.deck_controller.active_page:
+                        has_bg_video = True
                         # There is a background video
                         video_each_nth_frame = self.FPS // self.deck_controller.background.video.fps
                         if self.media_ticks % video_each_nth_frame == 0:
                             self.deck_controller.background.update_tiles()
 
-                #TODO: generalize
-                for key in self.deck_controller.inputs[Input.Key]:
-                    cast("ControllerKey", key).on_media_player_tick()
+                # Only iterate keys if there is animated content to update
+                if has_bg_video or self._needs_key_ticks():
+                    #TODO: generalize
+                    for key in self.deck_controller.inputs[Input.Key]:
+                        cast("ControllerKey", key).on_media_player_tick()
 
-                for dial in self.deck_controller.inputs[Input.Dial]:
-                    cast("ControllerDial", dial).on_media_player_tick()
-                # self.deck_controller.update_all_inputs()
+                    for dial in self.deck_controller.inputs[Input.Dial]:
+                        cast("ControllerDial", dial).on_media_player_tick()
+                    # self.deck_controller.update_all_inputs()
 
                 # Perform media player tasks
                 self.perform_media_player_tasks()
 
             self.media_ticks += 1
 
-            # Wait for approximately 1/30th of a second before the next call
             end = time.time()
-            # print(f"possible FPS: {1 / (end - start)}")
+
+            # Use low FPS when idle (no animated content, no pending tasks)
+            has_pending = bool(self.tasks or self.image_tasks or self.touchscreen_task)
+            if has_pending or has_bg_video or getattr(self, '_cached_needs_ticks', False):
+                target_fps = self.FPS
+            else:
+                target_fps = 2  # Idle: just check for new tasks occasionally
+
             self.append_fps(1 / (end - start))
             self.update_low_fps_warning()
-            wait = max(0, 1/self.FPS - (end - start))
-            time.sleep(wait)
+            wait = max(0, 1/target_fps - (end - start))
+            if target_fps < self.FPS:
+                self._wake_event.wait(wait)
+                self._wake_event.clear()
+            else:
+                time.sleep(wait)
 
             if self._stop:
                 break
 
         self.running = False
+
+    def _needs_key_ticks(self) -> bool:
+        # Check once per second whether any key has animated content
+        if self.media_ticks % self.FPS != 0:
+            return getattr(self, '_cached_needs_ticks', False)
+        needs = False
+        for key in self.deck_controller.inputs.get(Input.Key, []):
+            state = key.get_active_state()
+            if state.key_video is not None:
+                needs = True
+                break
+        self._cached_needs_ticks = needs
+        return needs
 
     def append_fps(self, fps: float) -> None:
         self.fps.append(fps)
@@ -254,6 +283,7 @@ class MediaPlayerThread(threading.Thread):
             args=args,
             kwargs=kwargs
         ))
+        self._wake_event.set()
 
     def add_touchscreen_task(self, native_image: bytes):
         self.touchscreen_task = MediaPlayerSetTouchscreenImageTask(
@@ -261,6 +291,7 @@ class MediaPlayerThread(threading.Thread):
             page=self.deck_controller.active_page,
             native_image=native_image
         )
+        self._wake_event.set()
 
     def add_image_task(self, key_index: int, native_image: bytes):
         self.image_tasks[key_index] = MediaPlayerSetImageTask(
@@ -269,6 +300,7 @@ class MediaPlayerThread(threading.Thread):
             key_index=key_index,
             native_image=native_image
         )
+        self._wake_event.set()
 
     def perform_media_player_tasks(self):
         for task in self.tasks.copy():
@@ -331,6 +363,7 @@ class DeckController:
 
         self.screen_saver = ScreenSaver(deck_controller=self)
         self.allow_interaction = True
+        self.has_animated_keys = False
 
         self.key_spacing = (36, 36)
 
@@ -1227,11 +1260,23 @@ class LabelManager:
         if update:
             self.update_label(position)
 
+    @staticmethod
+    def _label_equals(a: "KeyLabel", b: "KeyLabel") -> bool:
+        return (a.text == b.text and a.font_size == b.font_size
+                and a.font_name == b.font_name and a.color == b.color
+                and a.font_weight == b.font_weight and a.style == b.style
+                and a.outline_width == b.outline_width
+                and a.outline_color == b.outline_color
+                and a.alignment == b.alignment)
+
     def set_action_label(self, position: str, label: "KeyLabel", update: bool = True):
         if label is None:
             label = self.action_labels[position]
             label.clear_values()
         else:
+            old = self.action_labels.get(position)
+            if old is not None and self._label_equals(old, label):
+                return
             self.action_labels[position] = label
 
         self._has_scroll_labels_cache = None
@@ -2007,9 +2052,16 @@ class ControllerKey(ControllerInput):
         rows, cols = deck.key_layout()
         return y * cols + x
 
-    def update(self):
+    def update(self, force: bool = False):
         image = self.get_current_image()
-        
+
+        # Quick hash check - skip expensive conversion if image unchanged
+        img_hash = hash(image.tobytes())
+        if not force and img_hash == getattr(self, '_last_img_hash', None):
+            image.close()
+            return
+        self._last_img_hash = img_hash
+
         # Handle transparency properly - composite RGBA onto RGB to preserve smooth edges
         if image.mode == "RGBA":
             rgb_background = Image.new("RGB", image.size, (0, 0, 0))

--- a/src/backend/WindowGrabber/Integrations/KDE.py
+++ b/src/backend/WindowGrabber/Integrations/KDE.py
@@ -99,7 +99,7 @@ class KDE(Integration):
         return windows
 
     @log.catch
-    def get_active_window(self) -> Window:
+    def get_active_window_id(self) -> Optional[str]:
         try:
             kdotool = self._run_command(["kdotool", "getactivewindow"])
             if kdotool is None:
@@ -108,11 +108,16 @@ class KDE(Integration):
             window_id = stdout.decode().strip()
             if len(window_id) == 0:
                 return
-
-            return self.get_window(window_id)
-
+            return window_id
         except CalledProcessError as e:
             log.error(f"An error occurred while running kdotool: {e}")
+
+    @log.catch
+    def get_active_window(self) -> Window:
+        window_id = self.get_active_window_id()
+        if window_id is None:
+            return
+        return self.get_window(window_id)
 
     @log.catch
     def get_window(self, window_id: str) -> Optional[Window]:
@@ -154,13 +159,26 @@ class WatchForActiveWindowChange(threading.Thread):
         super().__init__(name="WatchForActiveWindowChange", daemon=True)
         self.kde = kde
 
-        self.last_active_window = self.kde.get_active_window()
+        self.last_window_id: Optional[str] = None
+        self.last_active_window: Optional[Window] = None
+
+        window_id = self.kde.get_active_window_id()
+        if window_id is not None:
+            self.last_window_id = window_id
+            self.last_active_window = self.kde.get_window(window_id)
 
     @log.catch
     def run(self) -> None:
         while gl.threads_running:
             time.sleep(0.2)
-            new_active_window = self.kde.get_active_window()
+            window_id = self.kde.get_active_window_id()
+            if window_id is None:
+                continue
+            if window_id == self.last_window_id:
+                continue
+
+            self.last_window_id = window_id
+            new_active_window = self.kde.get_window(window_id)
             if new_active_window is None:
                 continue
             if new_active_window == self.last_active_window:


### PR DESCRIPTION
## Summary

StreamController idles at ~25-30% CPU on KDE Wayland with flatpak, even with no user interaction. Profiling revealed three independent causes, all in `DeckController.py`:

- **KDE WindowGrabber** spawns 3 subprocesses (via `flatpak-spawn` + `kdotool`) every 200ms even when the active window hasn't changed. Now only fetches window name/class when the window ID actually changes (1 subprocess/cycle instead of 3).

- **MediaPlayer loop** runs at 30 FPS unconditionally, iterating all keys every tick. Now drops to 2 FPS when no animated content (video/GIF) is active and ramps back instantly when needed. Keys without video/GIF content are skipped entirely.

- **Plugin tick rendering** — plugins like CPUTemp call `set_center_label()` every tick with the same value, triggering full Pillow image renders (freetype font measurement + compositing + native format conversion) unnecessarily. Added label equality check to skip redundant renders, and an image hash guard in `ControllerKey.update()` to catch remaining cases.

Tested on CachyOS (KDE Plasma 6 Wayland) with Stream Deck MK.2 + XL (47 keys total), 12 plugins installed.

  Fixes #433
  Relates to #555
  Relates to #123

## Test plan

- [ ] Verify idle CPU drops significantly (~25% → ~3% on dual-deck setup)
- [ ] Verify GIF/video key animations still play at full FPS
- [ ] Verify background video wallpapers still animate
- [ ] Verify label scrolling still works for long text
- [ ] Verify plugin `on_tick` updates still appear (CPUTemp, MicMute, Weather)
- [ ] Verify key press responsiveness is unchanged
- [ ] Verify automatic page switching (KDE window grabber) still works