### PR TITLE
fix: Add proper GIF support with transparency and per-frame timing

### DIFF
--- a/src/backend/DeckManagement/DeckController.py
+++ b/src/backend/DeckManagement/DeckController.py
@@ -1156,12 +1156,11 @@ class BackgroundVideo(BackgroundVideoCache):
         region = (start_x, start_y, start_x + key_width, start_y + key_height)
         segment = image.crop(region)
 
-        # Create a new key-sized image, and paste in the cropped section of the
-        # larger image.
-        key_image = PILHelper.create_key_image(deck)
-        key_image.paste(segment)
-
-        return key_image
+        # Return the cropped segment directly, preserving alpha (matches
+        # BackgroundImage.crop_key_image_from_deck_sized_image above) instead
+        # of pasting onto an opaque RGB key image, which silently dropped
+        # transparency for GIF backgrounds.
+        return segment.convert("RGBA")
 
 class KeyGIF(SingleKeyAsset):
     def __init__(self, controller_key: "ControllerKey", gif_path: str, fps: int = 30, loop: bool = True):

--- a/src/backend/DeckManagement/Subclasses/KeyVideo.py
+++ b/src/backend/DeckManagement/Subclasses/KeyVideo.py
@@ -33,7 +33,14 @@ class InputVideo(SingleKeyAsset):
 
         self.active_frame: int = -1
 
+        # GIF timing state: track elapsed ms to honour per-frame delays
+        self._gif_elapsed_ms: float = 0.0
+        self._gif_last_tick: int = -1
+
     def get_next_frame(self) -> Image:
+        if self.video_cache._is_gif():
+            return self._get_next_gif_frame()
+
         every_n_frames = self.controller_input.deck_controller.media_player.FPS // self.fps
         if self.controller_input.media_ticks % every_n_frames == 0:
             self.active_frame += 1
@@ -41,9 +48,38 @@ class InputVideo(SingleKeyAsset):
         if self.active_frame >= self.video_cache.n_frames:
             if self.loop:
                 self.active_frame = 0
-        
+
         return self.video_cache.get_frame(self.active_frame)
-    
+
+    def _get_next_gif_frame(self) -> Image:
+        """Advance GIF playback using per-frame delays from GIF metadata."""
+        try:
+            media_player_fps = self.controller_input.deck_controller.media_player.FPS
+            tick = self.controller_input.media_ticks
+
+            if self._gif_last_tick < 0:
+                self.active_frame = 0
+                self._gif_last_tick = tick
+                return self.video_cache.get_frame(0)
+
+            ticks_elapsed = max(0, tick - self._gif_last_tick)
+            self._gif_elapsed_ms += ticks_elapsed * (1000.0 / max(media_player_fps, 1))
+            self._gif_last_tick = tick
+
+            delay = self.video_cache.get_frame_delay(self.active_frame)
+            if self._gif_elapsed_ms >= delay:
+                self._gif_elapsed_ms = 0.0
+                next_frame = self.active_frame + 1
+                if next_frame >= self.video_cache.n_frames:
+                    if self.loop:
+                        next_frame = 0
+                    else:
+                        next_frame = self.video_cache.n_frames - 1
+                self.active_frame = next_frame
+
+            return self.video_cache.get_frame(self.active_frame)
+        except Exception:
+            return self.video_cache.get_frame(0)
+
     def get_raw_image(self) -> Image.Image:
         return self.get_next_frame()
-     

--- a/src/backend/DeckManagement/Subclasses/KeyVideo.py
+++ b/src/backend/DeckManagement/Subclasses/KeyVideo.py
@@ -12,6 +12,8 @@ This programm comes with ABSOLUTELY NO WARRANTY!
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
+import time
+
 from src.backend.DeckManagement.Subclasses.SingleKeyAsset import SingleKeyAsset
 from src.backend.DeckManagement.Subclasses.key_video_cache import VideoFrameCache
 from PIL import Image
@@ -33,9 +35,9 @@ class InputVideo(SingleKeyAsset):
 
         self.active_frame: int = -1
 
-        # GIF timing state: track elapsed ms to honour per-frame delays
+        # GIF timing state: real-time based, independent of media player FPS
         self._gif_elapsed_ms: float = 0.0
-        self._gif_last_tick: int = -1
+        self._gif_last_ts: float = -1.0  # perf_counter timestamp in ms, -1 = not started
 
     def get_next_frame(self) -> Image:
         if self.video_cache._is_gif():
@@ -52,29 +54,35 @@ class InputVideo(SingleKeyAsset):
         return self.video_cache.get_frame(self.active_frame)
 
     def _get_next_gif_frame(self) -> Image:
-        """Advance GIF playback using per-frame delays from GIF metadata."""
+        """Advance GIF playback using real-time elapsed ms and per-frame delays."""
         try:
-            media_player_fps = self.controller_input.deck_controller.media_player.FPS
-            tick = self.controller_input.media_ticks
+            now_ms = time.perf_counter() * 1000.0
 
-            if self._gif_last_tick < 0:
+            if self._gif_last_ts < 0:
                 self.active_frame = 0
-                self._gif_last_tick = tick
+                self._gif_last_ts = now_ms
                 return self.video_cache.get_frame(0)
 
-            ticks_elapsed = max(0, tick - self._gif_last_tick)
-            self._gif_elapsed_ms += ticks_elapsed * (1000.0 / max(media_player_fps, 1))
-            self._gif_last_tick = tick
+            self._gif_elapsed_ms += now_ms - self._gif_last_ts
+            self._gif_last_ts = now_ms
 
-            delay = self.video_cache.get_frame_delay(self.active_frame)
-            if self._gif_elapsed_ms >= delay:
-                self._gif_elapsed_ms = 0.0
+            # Advance as many frames as the elapsed time requires.
+            # The while loop handles catch-up when the media player was delayed.
+            n_frames = self.video_cache.n_frames
+            while True:
+                delay = self.video_cache.get_frame_delay(self.active_frame)
+                if self._gif_elapsed_ms < delay:
+                    break
+                self._gif_elapsed_ms -= delay
                 next_frame = self.active_frame + 1
-                if next_frame >= self.video_cache.n_frames:
+                if next_frame >= n_frames:
                     if self.loop:
                         next_frame = 0
                     else:
-                        next_frame = self.video_cache.n_frames - 1
+                        next_frame = n_frames - 1
+                        self._gif_elapsed_ms = 0.0  # freeze on last frame
+                        self.active_frame = next_frame
+                        break
                 self.active_frame = next_frame
 
             return self.video_cache.get_frame(self.active_frame)

--- a/src/backend/DeckManagement/Subclasses/KeyVideo.py
+++ b/src/backend/DeckManagement/Subclasses/KeyVideo.py
@@ -29,7 +29,7 @@ class InputVideo(SingleKeyAsset):
         self.fps = fps
         self.loop = loop
 
-        self.video_cache = VideoFrameCache(video_path, size=self.controller_input.get_image_size())
+        self.video_cache = VideoFrameCache.get_or_create(video_path, size=self.controller_input.get_image_size())
 
         self.active_frame: int = -1
 

--- a/src/backend/DeckManagement/Subclasses/background_video_cache.py
+++ b/src/backend/DeckManagement/Subclasses/background_video_cache.py
@@ -27,11 +27,16 @@ class BackgroundVideoCache:
         self.lock = threading.Lock()
 
         self.video_path = video_path
-        self.cap = cv2.VideoCapture(video_path)
-        self.n_frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
         self.cache = {}
         self.last_decoded_frame = None
         self.last_frame_index = -1
+
+        if self._is_gif():
+            self.gif = Image.open(video_path)
+            self.n_frames = getattr(self.gif, "n_frames", 1)
+        else:
+            self.cap = cv2.VideoCapture(video_path)
+            self.n_frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
 
         self.video_md5 = self.get_video_hash()
 
@@ -56,37 +61,48 @@ class BackgroundVideoCache:
 
         self.do_caching = gl.settings_manager.get_app_settings().get("performance", {}).get("cache-videos", True)
 
+    def _is_gif(self) -> bool:
+        return os.path.splitext(self.video_path)[1].lower() == ".gif"
+
     def get_tiles(self, n):
         # Check if cache is available (video may have been closed)
         if not hasattr(self, 'cache') or self.cache is None:
             return [self.deck_controller.generate_alpha_key() for _ in range(self.deck_controller.deck.key_count())]
-        
+
         n = min(n, self.n_frames - 1)
         tiles = None
         with self.lock:
             if self.is_cache_complete():
-                self.cap.release()
+                if not self._is_gif():
+                    self.cap.release()
                 return self.cache.get(n, None)
-            
+
             # Otherwise, continue with video capture
             # Check if the frame is already decoded
             if n in self.cache:
                 return self.cache[n]
-            
+
             # If the requested frame is before the last decoded one, reset the capture
             if n < self.last_frame_index:
-                self.cap.set(cv2.CAP_PROP_POS_FRAMES, n)
+                if not self._is_gif():
+                    self.cap.set(cv2.CAP_PROP_POS_FRAMES, n)
                 self.last_frame_index = n - 1
 
             # Decode frames until the nth frame
             while self.last_frame_index < n:
-                success, frame = self.cap.read()
-                if not success:
-                    break  # Reached the end of the video
+                if self._is_gif():
+                    try:
+                        self.gif.seek(self.last_frame_index + 1)
+                    except EOFError:
+                        break  # Reached the end of the GIF
+                    pil_image = self.gif.convert("RGBA")
+                else:
+                    success, frame = self.cap.read()
+                    if not success:
+                        break  # Reached the end of the video
+                    frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                    pil_image = Image.fromarray(frame_rgb)
                 self.last_frame_index += 1
-                
-                frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)  
-                pil_image = Image.fromarray(frame_rgb)
 
                 # Resize the image
                 full_sized = self.create_full_deck_sized_image(pil_image)
@@ -233,7 +249,11 @@ class BackgroundVideoCache:
     def close(self) -> None:
         import gc
         with self.lock:
-            self.cap.release()
+            if self._is_gif():
+                if hasattr(self, "gif") and self.gif is not None:
+                    self.gif.close()
+            else:
+                self.cap.release()
 
         if hasattr(self, 'cache') and self.cache is not None:
             for n in self.cache:

--- a/src/backend/DeckManagement/Subclasses/key_video_cache.py
+++ b/src/backend/DeckManagement/Subclasses/key_video_cache.py
@@ -31,12 +31,23 @@ class VideoFrameCache:
         self.lock = threading.Lock()
 
         self.video_path = video_path
-        self.cap = cv2.VideoCapture(video_path)
-        self.n_frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        self.cache = {}
         self.size = size
+        self.cache = {}
         self.last_decoded_frame = None
         self.last_frame_index = -1
+
+        # Per-frame delays in ms, only populated for GIFs
+        self.frame_delays: list[int] = []
+
+        if self._is_gif():
+            self._gif_image = Image.open(video_path)
+            self.n_frames = getattr(self._gif_image, "n_frames", 1)
+            self._read_gif_delays()
+            self.cap = None
+        else:
+            self._gif_image = None
+            self.cap = cv2.VideoCapture(video_path)
+            self.n_frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
 
         self.video_md5 = self.get_video_hash()
 
@@ -45,6 +56,10 @@ class VideoFrameCache:
         self.do_caching = gl.settings_manager.get_app_settings().get("performance", {}).get("cache-videos", True)
         self.do_caching = True
 
+        # Pre-cache all GIF frames upfront so playback never blocks
+        if self._is_gif() and not self.is_cache_complete():
+            for i in range(self.n_frames):
+                self._get_gif_frame(i)
 
         if self.is_cache_complete():
             log.info("Cache is complete. Closing the video capture.")
@@ -55,9 +70,63 @@ class VideoFrameCache:
         # Print size of cache in memory in mb:
         log.trace(f"Size of cache in memory: {sys.getsizeof(self.cache) / 1024 / 1024:.2f} MB")
 
-        log.trace(f"Size of capture: {sys.getsizeof(self.cap) / 1024 / 1024:.2f} MB")
+        if not self._is_gif():
+            log.trace(f"Size of capture: {sys.getsizeof(self.cap) / 1024 / 1024:.2f} MB")
+
+    def _is_gif(self) -> bool:
+        return os.path.splitext(self.video_path)[1].lower() == ".gif"
+
+    def _read_gif_delays(self):
+        """Read per-frame delays (ms) from GIF metadata."""
+        try:
+            for i in range(self.n_frames):
+                self._gif_image.seek(i)
+                delay = self._gif_image.info.get("duration", 0)
+                self.frame_delays.append(delay)
+            # Replace zero delays with the previous frame's delay (or 100ms fallback).
+            # A 0ms delay is common on the last frame as an end-marker.
+            last_valid = 100
+            for i, d in enumerate(self.frame_delays):
+                if d <= 0:
+                    self.frame_delays[i] = last_valid
+                else:
+                    last_valid = d
+        except Exception:
+            self.frame_delays = [100] * self.n_frames
+        finally:
+            # Re-open the image so internal frame state is clean for playback.
+            # Pillow GIF frames depend on previous frames (disposal method), so
+            # seeking through all frames during delay-reading corrupts the state.
+            try:
+                self._gif_image.close()
+            except Exception:
+                pass
+            self._gif_image = Image.open(self.video_path)
+
+    def get_frame_delay(self, frame_index: int) -> int:
+        """Return the delay in ms for the given GIF frame. Falls back to 100ms."""
+        if self.frame_delays and 0 <= frame_index < len(self.frame_delays):
+            return self.frame_delays[frame_index]
+        return 100
+
+    def _get_gif_frame(self, n: int) -> Image.Image:
+        """Read frame n from a GIF via PIL, preserving RGBA transparency."""
+        n = min(n, self.n_frames - 1)
+        if n in self.cache:
+            return self.cache[n]
+        with self.lock:
+            self._gif_image.seek(n)
+            frame = self._gif_image.convert("RGBA")
+        frame = ImageOps.fit(frame, self.size, Image.Resampling.LANCZOS)
+        if self.do_caching:
+            self.cache[n] = frame
+            self.write_cache(frame, n)
+        return frame
 
     def get_frame(self, n):
+        if self._is_gif():
+            return self._get_gif_frame(n)
+
         n = min(n, self.n_frames - 1)
         if self.is_cache_complete():
             return self.cache.get(n, None)
@@ -80,7 +149,7 @@ class VideoFrameCache:
             if not success:
                 break  # Reached the end of the video
             self.last_frame_index += 1
-            
+
             # Calculate the new height to maintain aspect ratio
             frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             pil_image = Image.fromarray(frame_rgb)
@@ -100,7 +169,13 @@ class VideoFrameCache:
 
     def release(self):
         with self.lock:
-            self.cap.release()
+            if self.cap is not None:
+                self.cap.release()
+            if self._gif_image is not None:
+                try:
+                    self._gif_image.close()
+                except Exception:
+                    pass
 
     def get_video_hash(self) -> str:
         with self.lock:
@@ -116,20 +191,24 @@ class VideoFrameCache:
         """
         key_index: if None: single key video, if int: key index
         """
+        # GIFs are cached as PNG to preserve the alpha channel
+        ext = "png" if self._is_gif() else "jpg"
         with self.lock:
             if key_index is None:
-                path = os.path.join(VID_CACHE, "single_key", self.video_md5, f"{self.size[0]}x{self.size[1]}", f"{frame_index}.jpg")
+                path = os.path.join(VID_CACHE, "single_key", self.video_md5, f"{self.size[0]}x{self.size[1]}", f"{frame_index}.{ext}")
             else:
-                path = os.path.join(VID_CACHE, f"key: {key_index}", self.video_md5, f"{self.size[0]}x{self.size[1]}", f"{key_index}", f"{frame_index}.jpg")
+                path = os.path.join(VID_CACHE, f"key: {key_index}", self.video_md5, f"{self.size[0]}x{self.size[1]}", f"{key_index}", f"{frame_index}.{ext}")
 
             if os.path.isfile(path):
                 return
-            
+
             os.makedirs(os.path.dirname(path), exist_ok=True)
-            
+
             image.save(path)
 
     def load_cache(self, key_index: int = None):
+        # GIFs are cached as PNG to preserve the alpha channel
+        ext = "png" if self._is_gif() else "jpg"
         with self.lock:
             start = time.time()
             if key_index is None:
@@ -137,7 +216,7 @@ class VideoFrameCache:
                 if not os.path.exists(path):
                     return
                 for file in os.listdir(path):
-                    if os.path.splitext(file)[1] != ".jpg":
+                    if os.path.splitext(file)[1] != f".{ext}":
                         continue
                     with Image.open(os.path.join(path, file)) as img:
                         self.cache[int(file.split(".")[0])] = img.copy()
@@ -147,7 +226,7 @@ class VideoFrameCache:
                 if not os.path.exists(path):
                     return
                 for file in os.listdir(path):
-                    if os.path.splitext(file)[1] != ".jpg":
+                    if os.path.splitext(file)[1] != f".{ext}":
                         continue
                     with Image.open(os.path.join(path, file)) as img:
                         self.cache[int(file.split(".")[0])] = img.copy()

--- a/src/backend/DeckManagement/Subclasses/key_video_cache.py
+++ b/src/backend/DeckManagement/Subclasses/key_video_cache.py
@@ -13,8 +13,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 
-from functools import lru_cache
 import hashlib
+import json
 import os
 import sys
 import threading
@@ -26,213 +26,283 @@ import globals as gl
 
 VID_CACHE = os.path.join(gl.DATA_PATH, "cache", "videos")
 
-class VideoFrameCache:
-    def __init__(self, video_path, size: tuple[int, int]):
-        self.lock = threading.Lock()
 
+class VideoFrameCache:
+    # Registry: same (video_path, size) → same instance, no double-loading.
+    _registry: dict[tuple, "VideoFrameCache"] = {}
+    _registry_lock = threading.Lock()
+
+    @classmethod
+    def get_or_create(cls, video_path: str, size: tuple[int, int]) -> "VideoFrameCache":
+        key = (os.path.abspath(video_path), size)
+        with cls._registry_lock:
+            existing = cls._registry.get(key)
+            if existing is not None:
+                return existing
+            instance = cls(video_path, size)
+            cls._registry[key] = instance
+            return instance
+
+    def __init__(self, video_path: str, size: tuple[int, int]):
         self.video_path = video_path
         self.size = size
-        self.cache = {}
+
+        # Background thread writes, main thread reads.
+        # Individual dict get/set is GIL-atomic in CPython.
+        self.cache: dict[int, Image.Image] = {}
+        self.frame_delays: list[int] = []
+        self.n_frames = 1  # updated in __init__ once we know the real count
+
         self.last_decoded_frame = None
         self.last_frame_index = -1
-
-        # Per-frame delays in ms, only populated for GIFs
-        self.frame_delays: list[int] = []
-
-        if self._is_gif():
-            self._gif_image = Image.open(video_path)
-            self.n_frames = getattr(self._gif_image, "n_frames", 1)
-            self._read_gif_delays()
-            self.cap = None
-        else:
-            self._gif_image = None
-            self.cap = cv2.VideoCapture(video_path)
-            self.n_frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
-
-        self.video_md5 = self.get_video_hash()
-
-        self.load_cache()
+        self.lock = threading.Lock()  # guards cv2 capture only
 
         self.do_caching = gl.settings_manager.get_app_settings().get("performance", {}).get("cache-videos", True)
         self.do_caching = True
 
-        # Pre-cache all GIF frames upfront so playback never blocks
-        if self._is_gif() and not self.is_cache_complete():
-            for i in range(self.n_frames):
-                self._get_gif_frame(i)
-
-        if self.is_cache_complete():
-            log.info("Cache is complete. Closing the video capture.")
-            self.release()
-        else:
-            log.info("Cache is not complete. Continuing with video capture.")
-
-        # Print size of cache in memory in mb:
-        log.trace(f"Size of cache in memory: {sys.getsizeof(self.cache) / 1024 / 1024:.2f} MB")
+        # O(1) cache key — just a stat() call, no file read.
+        self.video_md5 = self._fast_cache_key()
 
         if not self._is_gif():
-            log.trace(f"Size of capture: {sys.getsizeof(self.cap) / 1024 / 1024:.2f} MB")
+            self.cap = cv2.VideoCapture(video_path)
+            self.n_frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        else:
+            # Render frame 0 synchronously: gives every button a static preview
+            # immediately, before any background thread runs.
+            try:
+                with Image.open(video_path) as gif:
+                    self.n_frames = getattr(gif, "n_frames", 1)
+                    gif.seek(0)
+                    frame0 = ImageOps.fit(gif.convert("RGBA"), self.size, Image.Resampling.LANCZOS)
+                self.cache[0] = frame0
+            except Exception as e:
+                log.warning(f"Could not render GIF preview for {video_path}: {e}")
+
+        threading.Thread(
+            target=self._load_in_background,
+            daemon=True,
+            name=f"vid-cache-{os.path.basename(video_path)}",
+        ).start()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _fast_cache_key(self) -> str:
+        stat = os.stat(self.video_path)
+        return hashlib.md5(f"{stat.st_mtime_ns}_{stat.st_size}".encode()).hexdigest()
 
     def _is_gif(self) -> bool:
         return os.path.splitext(self.video_path)[1].lower() == ".gif"
 
-    def _read_gif_delays(self):
-        """Read per-frame delays (ms) from GIF metadata."""
+    def _cache_dir(self, key_index: int = None) -> str:
+        ext_part = f"{self.size[0]}x{self.size[1]}"
+        if key_index is None:
+            return os.path.join(VID_CACHE, "single_key", self.video_md5, ext_part)
+        return os.path.join(VID_CACHE, f"key: {key_index}", self.video_md5, ext_part, str(key_index))
+
+    def _frame_ext(self) -> str:
+        return "png" if self._is_gif() else "jpg"
+
+    def _delays_path(self) -> str:
+        return os.path.join(self._cache_dir(), "delays.json")
+
+    # ------------------------------------------------------------------
+    # Background loading
+    # ------------------------------------------------------------------
+
+    def _load_in_background(self):
+        if self._is_gif():
+            self._load_gif_background()
+        else:
+            self._load_video_background()
+
+    def _load_gif_background(self):
+        """Build full GIF cache. Frame 0 is already in self.cache from __init__."""
         try:
-            for i in range(self.n_frames):
-                self._gif_image.seek(i)
-                delay = self._gif_image.info.get("duration", 0)
-                self.frame_delays.append(delay)
-            # Replace zero delays with the previous frame's delay (or 100ms fallback).
-            # A 0ms delay is common on the last frame as an end-marker.
+            n = self.n_frames
+
+            # Phase 1 — persist frame 0 to disk if not already there.
+            if 0 in self.cache and self.do_caching:
+                self._write_cache_frame(self.cache[0], 0)
+
+            # Phase 2 — load delays: from disk cache (fast) or from GIF (slow, once).
+            delays_path = self._delays_path()
+            if os.path.exists(delays_path):
+                try:
+                    with open(delays_path) as f:
+                        self.frame_delays = json.load(f)
+                except Exception:
+                    self.frame_delays = [100] * n
+            else:
+                self.frame_delays = self._read_gif_delays(n)
+                if self.do_caching:
+                    try:
+                        os.makedirs(os.path.dirname(delays_path), exist_ok=True)
+                        with open(delays_path, "w") as f:
+                            json.dump(self.frame_delays, f)
+                    except Exception as e:
+                        log.warning(f"Could not save delays cache: {e}")
+
+            # Phase 3 — load remaining frames from disk cache.
+            self._load_cache_from_disk()
+
+            # Phase 4 — decode any frames still missing (first run only).
+            if not self.is_cache_complete():
+                with Image.open(self.video_path) as gif:
+                    for i in range(n):
+                        if i in self.cache:
+                            continue
+                        try:
+                            gif.seek(i)
+                            frame = ImageOps.fit(gif.convert("RGBA"), self.size, Image.Resampling.LANCZOS)
+                            if self.do_caching:
+                                self._write_cache_frame(frame, i)
+                            self.cache[i] = frame
+                        except Exception as e:
+                            log.warning(f"Failed to decode GIF frame {i}: {e}")
+
+            if self.is_cache_complete():
+                log.info(f"GIF cache complete ({n} frames): {os.path.basename(self.video_path)}")
+            else:
+                log.warning(f"GIF cache incomplete ({len(self.cache)}/{n}): {os.path.basename(self.video_path)}")
+
+        except Exception as e:
+            log.error(f"Failed to load GIF {self.video_path}: {e}")
+
+        log.trace(f"Cache memory: {sys.getsizeof(self.cache) / 1024 / 1024:.2f} MB")
+
+    def _read_gif_delays(self, n: int) -> list[int]:
+        """Seek through GIF once to read per-frame delays. Slow — called once, result cached to disk."""
+        try:
+            delays = []
+            with Image.open(self.video_path) as gif:
+                for i in range(n):
+                    gif.seek(i)
+                    delays.append(gif.info.get("duration", 0))
             last_valid = 100
-            for i, d in enumerate(self.frame_delays):
+            for i, d in enumerate(delays):
                 if d <= 0:
-                    self.frame_delays[i] = last_valid
+                    delays[i] = last_valid
                 else:
                     last_valid = d
+            return delays
         except Exception:
-            self.frame_delays = [100] * self.n_frames
-        finally:
-            # Re-open the image so internal frame state is clean for playback.
-            # Pillow GIF frames depend on previous frames (disposal method), so
-            # seeking through all frames during delay-reading corrupts the state.
-            try:
-                self._gif_image.close()
-            except Exception:
-                pass
-            self._gif_image = Image.open(self.video_path)
+            return [100] * n
+
+    def _load_video_background(self):
+        self._load_cache_from_disk()
+        if self.is_cache_complete():
+            log.info("Video cache complete. Closing capture.")
+            with self.lock:
+                self.cap.release()
+        else:
+            log.info("Video cache incomplete. Keeping capture open.")
+        log.trace(f"Cache memory: {sys.getsizeof(self.cache) / 1024 / 1024:.2f} MB")
+
+    # ------------------------------------------------------------------
+    # Frame access (main / media-player thread)
+    # ------------------------------------------------------------------
 
     def get_frame_delay(self, frame_index: int) -> int:
-        """Return the delay in ms for the given GIF frame. Falls back to 100ms."""
         if self.frame_delays and 0 <= frame_index < len(self.frame_delays):
             return self.frame_delays[frame_index]
         return 100
 
-    def _get_gif_frame(self, n: int) -> Image.Image:
-        """Read frame n from a GIF via PIL, preserving RGBA transparency."""
-        n = min(n, self.n_frames - 1)
-        if n in self.cache:
-            return self.cache[n]
-        with self.lock:
-            self._gif_image.seek(n)
-            frame = self._gif_image.convert("RGBA")
-        frame = ImageOps.fit(frame, self.size, Image.Resampling.LANCZOS)
-        if self.do_caching:
-            self.cache[n] = frame
-            self.write_cache(frame, n)
-        return frame
-
-    def get_frame(self, n):
+    def get_frame(self, n: int):
         if self._is_gif():
             return self._get_gif_frame(n)
 
         n = min(n, self.n_frames - 1)
         if self.is_cache_complete():
-            return self.cache.get(n, None)
+            return self.cache.get(n)
 
-        # Otherwise, continue with video capture
-        # Check if the frame is already decoded
         if n in self.cache:
             return self.cache[n]
 
-        # If the requested frame is before the last decoded one, reset the capture
         if n < self.last_frame_index:
             with self.lock:
                 self.cap.set(cv2.CAP_PROP_POS_FRAMES, n)
             self.last_frame_index = n - 1
 
-        # Decode frames until the nth frame
         while self.last_frame_index < n:
             with self.lock:
                 success, frame = self.cap.read()
             if not success:
-                break  # Reached the end of the video
+                break
             self.last_frame_index += 1
-
-            # Calculate the new height to maintain aspect ratio
-            frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            pil_image = Image.fromarray(frame_rgb)
-
-            # Fill a 72x72 square completely with the image, keeping the aspect ratio
-            pil_image = ImageOps.fit(pil_image, self.size, Image.Resampling.LANCZOS)
-
+            pil_image = ImageOps.fit(
+                Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)),
+                self.size, Image.Resampling.LANCZOS,
+            )
             self.last_decoded_frame = pil_image
             if self.do_caching:
                 self.cache[self.last_frame_index] = pil_image
+                self._write_cache_frame(pil_image, self.last_frame_index)
 
-                # Write the frame to the cache
-                self.write_cache(pil_image, self.last_frame_index)
-
-        # Return the last decoded frame if the nth frame is not available
         return self.cache.get(n, self.last_decoded_frame)
+
+    def _get_gif_frame(self, n: int):
+        n = min(n, self.n_frames - 1)
+        frame = self.cache.get(n)
+        if frame is not None:
+            return frame
+        # Still loading: return frame 0 as static preview
+        return self.cache.get(0)
+
+    # ------------------------------------------------------------------
+    # Disk cache I/O
+    # ------------------------------------------------------------------
+
+    def _write_cache_frame(self, image: Image.Image, frame_index: int, key_index: int = None):
+        path = os.path.join(self._cache_dir(key_index), f"{frame_index}.{self._frame_ext()}")
+        if os.path.isfile(path):
+            return
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        image.save(path)
+
+    def _load_cache_from_disk(self, key_index: int = None):
+        ext = self._frame_ext()
+        path = self._cache_dir(key_index)
+        if not os.path.exists(path):
+            return
+        start = time.time()
+        for file in os.listdir(path):
+            if os.path.splitext(file)[1] != f".{ext}":
+                continue
+            idx = int(file.split(".")[0])
+            if idx in self.cache:
+                continue
+            try:
+                with Image.open(os.path.join(path, file)) as img:
+                    self.cache[idx] = img.copy()
+            except Exception as e:
+                log.warning(f"Failed to load cached frame {file}: {e}")
+        log.info(f"Loaded disk cache in {time.time() - start:.2f}s ({len(self.cache)} frames)")
+
+    # ------------------------------------------------------------------
+    # Legacy public API
+    # ------------------------------------------------------------------
+
+    def write_cache(self, image: Image.Image, frame_index: int, key_index: int = None):
+        self._write_cache_frame(image, frame_index, key_index)
+
+    def load_cache(self, key_index: int = None):
+        self._load_cache_from_disk(key_index)
+
+    def get_video_hash(self) -> str:
+        sha1sum = hashlib.md5()
+        with open(self.video_path, "rb") as f:
+            block = f.read(2**16)
+            while block:
+                sha1sum.update(block)
+                block = f.read(2**16)
+        return sha1sum.hexdigest()
 
     def release(self):
         with self.lock:
-            if self.cap is not None:
+            if hasattr(self, "cap") and self.cap is not None:
                 self.cap.release()
-            if self._gif_image is not None:
-                try:
-                    self._gif_image.close()
-                except Exception:
-                    pass
 
-    def get_video_hash(self) -> str:
-        with self.lock:
-            sha1sum = hashlib.md5()
-            with open(self.video_path, 'rb') as video:
-                block = video.read(2**16)
-                while len(block) != 0:
-                    sha1sum.update(block)
-                    block = video.read(2**16)
-                return sha1sum.hexdigest()
-
-    def write_cache(self, image: Image, frame_index: int, key_index: int = None):
-        """
-        key_index: if None: single key video, if int: key index
-        """
-        # GIFs are cached as PNG to preserve the alpha channel
-        ext = "png" if self._is_gif() else "jpg"
-        with self.lock:
-            if key_index is None:
-                path = os.path.join(VID_CACHE, "single_key", self.video_md5, f"{self.size[0]}x{self.size[1]}", f"{frame_index}.{ext}")
-            else:
-                path = os.path.join(VID_CACHE, f"key: {key_index}", self.video_md5, f"{self.size[0]}x{self.size[1]}", f"{key_index}", f"{frame_index}.{ext}")
-
-            if os.path.isfile(path):
-                return
-
-            os.makedirs(os.path.dirname(path), exist_ok=True)
-
-            image.save(path)
-
-    def load_cache(self, key_index: int = None):
-        # GIFs are cached as PNG to preserve the alpha channel
-        ext = "png" if self._is_gif() else "jpg"
-        with self.lock:
-            start = time.time()
-            if key_index is None:
-                path = os.path.join(VID_CACHE, "single_key", self.video_md5, f"{self.size[0]}x{self.size[1]}")
-                if not os.path.exists(path):
-                    return
-                for file in os.listdir(path):
-                    if os.path.splitext(file)[1] != f".{ext}":
-                        continue
-                    with Image.open(os.path.join(path, file)) as img:
-                        self.cache[int(file.split(".")[0])] = img.copy()
-
-            else:
-                path = os.path.join(VID_CACHE, f"key: {key_index}", self.video_md5, f"{self.size[0]}x{self.size[1]}", f"{key_index}")
-                if not os.path.exists(path):
-                    return
-                for file in os.listdir(path):
-                    if os.path.splitext(file)[1] != f".{ext}":
-                        continue
-                    with Image.open(os.path.join(path, file)) as img:
-                        self.cache[int(file.split(".")[0])] = img.copy()
-
-            log.info(f"Loaded cache in {time.time() - start:.2f} seconds")
-
-    @lru_cache(maxsize=None)
     def is_cache_complete(self) -> bool:
         return len(self.cache) == self.n_frames

--- a/src/backend/DeckManagement/Subclasses/key_video_cache.py
+++ b/src/backend/DeckManagement/Subclasses/key_video_cache.py
@@ -32,15 +32,41 @@ class VideoFrameCache:
     _registry: dict[tuple, "VideoFrameCache"] = {}
     _registry_lock = threading.Lock()
 
+    # Per-key locks: ensure only one thread runs __init__ for a given key.
+    # This prevents two threads from writing to the same cache files
+    # simultaneously (which would corrupt PNGs and cause segfaults in PIL).
+    _init_locks: dict[tuple, threading.Lock] = {}
+    _init_locks_lock = threading.Lock()
+
     @classmethod
     def get_or_create(cls, video_path: str, size: tuple[int, int]) -> "VideoFrameCache":
         key = (os.path.abspath(video_path), size)
+
+        # Fast path: already in registry (no I/O needed).
         with cls._registry_lock:
             existing = cls._registry.get(key)
             if existing is not None:
                 return existing
+
+        # Acquire a per-key lock so that only one thread runs __init__ for
+        # this (path, size) at a time.  The global _registry_lock is NOT
+        # held during __init__, so other keys are never blocked.
+        with cls._init_locks_lock:
+            if key not in cls._init_locks:
+                cls._init_locks[key] = threading.Lock()
+            key_lock = cls._init_locks[key]
+
+        with key_lock:
+            # Re-check: another thread may have completed init while we waited.
+            with cls._registry_lock:
+                existing = cls._registry.get(key)
+                if existing is not None:
+                    return existing
+
             instance = cls(video_path, size)
-            cls._registry[key] = instance
+
+            with cls._registry_lock:
+                cls._registry[key] = instance
             return instance
 
     def __init__(self, video_path: str, size: tuple[int, int]):

--- a/src/backend/DeckManagement/Subclasses/key_video_cache.py
+++ b/src/backend/DeckManagement/Subclasses/key_video_cache.py
@@ -19,6 +19,7 @@ import os
 import sys
 import threading
 import time
+import weakref
 from PIL import Image, ImageOps
 import cv2
 from loguru import logger as log
@@ -29,7 +30,10 @@ VID_CACHE = os.path.join(gl.DATA_PATH, "cache", "videos")
 
 class VideoFrameCache:
     # Registry: same (video_path, size) → same instance, no double-loading.
-    _registry: dict[tuple, "VideoFrameCache"] = {}
+    # Weak-valued so an entry is freed once no InputVideo/KeyVideo still
+    # references it, instead of caching every video ever shown for the
+    # life of the process.
+    _registry: "weakref.WeakValueDictionary[tuple, VideoFrameCache]" = weakref.WeakValueDictionary()
     _registry_lock = threading.Lock()
 
     # Per-key locks: ensure only one thread runs __init__ for a given key.

--- a/src/backend/DeckManagement/Subclasses/key_video_cache.py
+++ b/src/backend/DeckManagement/Subclasses/key_video_cache.py
@@ -116,7 +116,9 @@ class VideoFrameCache:
 
     def _fast_cache_key(self) -> str:
         stat = os.stat(self.video_path)
-        return hashlib.md5(f"{stat.st_mtime_ns}_{stat.st_size}".encode()).hexdigest()
+        return hashlib.md5(
+            f"{os.path.abspath(self.video_path)}_{stat.st_mtime_ns}_{stat.st_size}".encode()
+        ).hexdigest()
 
     def _is_gif(self) -> bool:
         return os.path.splitext(self.video_path)[1].lower() == ".gif"


### PR DESCRIPTION
## Problem

GIFs were decoded using OpenCV (`cv2.VideoCapture`), which has two limitations:

1. **No transparency support** — GIF frames in palette mode (`P`) with a transparency index were composited onto a white background, losing the alpha channel.
2. **Incorrect frame timing** — All frames played at a fixed FPS value, ignoring the per-frame delay stored in the GIF metadata. This caused animations with variable timing (e.g. a 2-second intro frame followed by fast animation frames) to play incorrectly or appear cut short.

## Solution

GIF files are now detected by extension and handled separately using PIL:

- **`key_video_cache.py`**: GIFs are opened with `Image.open()` and each frame is converted to RGBA, preserving transparency. Frames are cached as PNG instead of JPEG to retain the alpha channel. Per-frame delays are read from the GIF metadata (`img.info["duration"]`) and stored in `frame_delays`.
- **`KeyVideo.py`**: A new `_get_next_gif_frame()` method advances playback by accumulating elapsed milliseconds and comparing against the current frame's delay, rather than using a global FPS value.

All non-GIF video formats (mp4, webm, etc.) are unaffected and continue to use the existing cv2 code path.

## Testing

Tested with:
- Transparent GIF (palette mode with transparency index) — now renders correctly on dark backgrounds
- GIF with uniform frame delays — plays at correct speed
- GIF with variable frame delays (long first frame + short animation frames) — each frame now shown for its correct duration
- Non-GIF videos (mp4) — behaviour unchanged