### PR TITLE
Fix semaphore leak

### DIFF
--- a/src/backend/DeckManagement/HelperMethods.py
+++ b/src/backend/DeckManagement/HelperMethods.py
@@ -16,7 +16,6 @@ from datetime import datetime
 from functools import lru_cache
 import hashlib
 from io import BytesIO
-import multiprocessing
 import os
 import subprocess
 import matplotlib.font_manager
@@ -362,9 +361,8 @@ def run_command(command):
     if is_flatpak():
         command = "flatpak-spawn --host " + command
 
-    p = multiprocessing.Process(target=subprocess.Popen, args=[command], kwargs={
-                                "shell": True, "start_new_session": True, "stdin": subprocess.DEVNULL, "stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL, "cwd": os.path.expanduser("~")})
-    p.start()
+    subprocess.Popen(command, shell=True, start_new_session=True, stdin=subprocess.DEVNULL,
+                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.expanduser("~"))
 
 def open_web(url):
     if not url.startswith("http"):

--- a/src/backend/DeckManagement/HelperMethods.py
+++ b/src/backend/DeckManagement/HelperMethods.py
@@ -34,6 +34,7 @@ from gi.repository import Gdk, Pango
 
 # Import globals
 from autostart import is_flatpak
+from loguru import logger as log
 import globals as gl
 
 
@@ -359,8 +360,11 @@ def open_web(url):
     argv = ["xdg-open", url]
     if is_flatpak():
         argv = ["flatpak-spawn", "--host"] + argv
-    subprocess.Popen(argv, start_new_session=True, stdin=subprocess.DEVNULL,
-                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.expanduser("~"))
+    try:
+        subprocess.Popen(argv, start_new_session=True, stdin=subprocess.DEVNULL,
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.expanduser("~"))
+    except (FileNotFoundError, OSError) as e:
+        log.error(f"Failed to open URL {url}: {e}")
 
 def svg_string_to_pil(svg_string, width: int = 96, height: int = 96):
     """

--- a/src/backend/DeckManagement/HelperMethods.py
+++ b/src/backend/DeckManagement/HelperMethods.py
@@ -353,17 +353,6 @@ def sort_times(time_list):
     """
     return sorted(time_list, key=lambda x: datetime.fromisoformat(x))
 
-
-def run_command(command):
-    if command is None:
-        return
-
-    if is_flatpak():
-        command = "flatpak-spawn --host " + command
-
-    subprocess.Popen(command, shell=True, start_new_session=True, stdin=subprocess.DEVNULL,
-                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.expanduser("~"))
-
 def open_web(url):
     if not url.startswith("http"):
         url = f"https://{url}"

--- a/src/backend/DeckManagement/HelperMethods.py
+++ b/src/backend/DeckManagement/HelperMethods.py
@@ -367,7 +367,11 @@ def run_command(command):
 def open_web(url):
     if not url.startswith("http"):
         url = f"https://{url}"
-    run_command(f"xdg-open {url}")
+    argv = ["xdg-open", url]
+    if is_flatpak():
+        argv = ["flatpak-spawn", "--host"] + argv
+    subprocess.Popen(argv, start_new_session=True, stdin=subprocess.DEVNULL,
+                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.expanduser("~"))
 
 def svg_string_to_pil(svg_string, width: int = 96, height: int = 96):
     """

--- a/src/backend/DeckManagement/HelperMethods.py
+++ b/src/backend/DeckManagement/HelperMethods.py
@@ -34,6 +34,7 @@ from gi.repository import Gdk, Pango
 
 # Import globals
 from autostart import is_flatpak
+from loguru import logger as log
 import globals as gl
 
 
@@ -353,16 +354,18 @@ def sort_times(time_list):
     """
     return sorted(time_list, key=lambda x: datetime.fromisoformat(x))
 
-
-def run_command(command):
+def run_command(command: str):
     if command is None:
         return
 
+    argv = command.split(" ")
     if is_flatpak():
-        command = "flatpak-spawn --host " + command
-
-    subprocess.Popen(command, shell=True, start_new_session=True, stdin=subprocess.DEVNULL,
-                     stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.expanduser("~"))
+        argv = ["flatpak-spawn", "--host"] + argv
+    try:
+        subprocess.Popen(argv, start_new_session=True, stdin=subprocess.DEVNULL,
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.expanduser("~"))
+    except (FileNotFoundError, OSError) as e:
+        log.error(f"Failed to run command {" ".join(argv)}: {e}")
 
 def open_web(url):
     if not url.startswith("http"):

--- a/src/backend/DeckManagement/HelperMethods.py
+++ b/src/backend/DeckManagement/HelperMethods.py
@@ -370,14 +370,7 @@ def run_command(command: str):
 def open_web(url):
     if not url.startswith("http"):
         url = f"https://{url}"
-    argv = ["xdg-open", url]
-    if is_flatpak():
-        argv = ["flatpak-spawn", "--host"] + argv
-    try:
-        subprocess.Popen(argv, start_new_session=True, stdin=subprocess.DEVNULL,
-                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=os.path.expanduser("~"))
-    except (FileNotFoundError, OSError) as e:
-        log.error(f"Failed to open URL {url}: {e}")
+    run_command(f"xdg-open {url}")
 
 def svg_string_to_pil(svg_string, width: int = 96, height: int = 96):
     """

--- a/src/windows/Onboarding/OnboardingWindow.py
+++ b/src/windows/Onboarding/OnboardingWindow.py
@@ -12,19 +12,16 @@ This programm comes with ABSOLUTELY NO WARRANTY!
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
-# Import gtk modules
-from asyncio import wrap_future
 import asyncio
 import os
 import threading
 import gi
 import subprocess
 from packaging import version
-import webbrowser as web
 
 from GtkHelper.GtkHelper import LoadingScreen
 from autostart import is_flatpak
-from src.backend.DeckManagement.HelperMethods import open_web, run_command
+from src.backend.DeckManagement.HelperMethods import open_web
 from src.windows.Onboarding.PluginRecommendations import PluginRecommendations
 
 gi.require_version("Gtk", "4.0")
@@ -51,7 +48,7 @@ class OnboardingWindow(Adw.Dialog):
         self.set_follows_content_size(False)
 
         self.connect("close-attempt", self.on_close)
-        
+
         self.build()
 
     def build(self):
@@ -265,7 +262,7 @@ class ExtensionOnboardingScreen(Gtk.Box):
             self.install_button.set_sensitive(False)
             # Allow retry after 1 second
             GLib.timeout_add(1000, self.set_button_status, "uninstalled")
-            
+
         # To stop potential GLib.timeout_add
         return False
 
@@ -394,7 +391,7 @@ class SupportAppOnboardingScreen(Gtk.Box):
         self.append(self.support_button)
 
     def on_support_button_clicked(self, button):
-        run_command("xdg-open https://ko-fi.com/core447")
+        open_web("https://ko-fi.com/core447")
         # portal = Xdp.Portal.new()
         # portal.open_uri(
         #     parent=XdpGtk4.parent_new_gtk(gl.app.get_active_window()),


### PR DESCRIPTION
Running the git version of StreamController directly, it would very often crash for me with this or similar errors:
```
/usr/lib/python3.14/multiprocessing/resource_tracker.py:297: UserWarning: resource_tracker: There appear to be 8 leaked semaphore objects to clean up at shutdown: {'/mp-jvnwx97h', '/mp-cguo3zu8', '/mp-gkf96e_6', '/mp-go1e2_ae', '/mp-mnbqf7w1', '/mp-8yryfp80', '/mp-wsz2uv6z', '/mp-hhrjz222'}
  warnings.warn(
```

I told Copilot to investigate and it proposed this change; its reasoning:

>Fix: replace the multiprocessing.Process wrapper with a direct subprocess.Popen call in run_command() in src/backend/DeckManagement/HelperMethods.py.
>
>This eliminates the POSIX semaphore creation entirely for run_command calls. The detached subprocess is already fully independent of the parent process via start_new_session=True.

I did not have a single crash with this change and everything still works as I would expect. Additionally, I have a user of the HomeAssistantPlugin reporting crashes when changing pages which I suspect might be linked because the crash for me would often occur on page changes.