### PR TITLE
Fix GTK calls from non-main threads (same SIGSEGV class as #566)

### DIFF
--- a/src/backend/DeckManagement/DeckManager.py
+++ b/src/backend/DeckManagement/DeckManager.py
@@ -205,7 +205,11 @@ class DeckManager:
     def remove_controller(self, deck_controller: DeckController) -> None:
         self.deck_controller.remove(deck_controller)
         if recursive_hasattr(gl, "app.main_win.leftArea.deck_stack"):
-            gl.app.main_win.leftArea.deck_stack.remove_page(deck_controller)
+            # remove_controller() is called from non-GTK threads (e.g.
+            # FlatpakDeckDisconnectThread, udev callbacks); route the GTK call
+            # through the main loop like add_newly_connected_deck() does for
+            # add_page().
+            GLib.idle_add(gl.app.main_win.leftArea.deck_stack.remove_page, deck_controller)
         deck_controller.delete()
         del deck_controller
 

--- a/src/windows/mainWindow/elements/Sidebar/elements/ActionMissing/MissingRow.py
+++ b/src/windows/mainWindow/elements/Sidebar/elements/ActionMissing/MissingRow.py
@@ -113,10 +113,12 @@ class MissingRow(Adw.PreferencesRow):
         threading.Timer(3, self.hide_install_error).start()
 
     def hide_install_error(self):
-        self.label.set_text(self.install_label)
-        self.remove_css_class("error")
-        self.set_sensitive(True)
-        self.main_button.set_sensitive(True)
+        # Runs on a threading.Timer thread; GTK calls must go through the
+        # main loop.
+        GLib.idle_add(self.label.set_text, self.install_label)
+        GLib.idle_add(self.remove_css_class, "error")
+        GLib.idle_add(self.set_sensitive, True)
+        GLib.idle_add(self.main_button.set_sensitive, True)
 
     def on_remove_click(self, button):
         controller = gl.app.main_win.leftArea.deck_stack.get_visible_child().deck_controller

--- a/src/windows/mainWindow/mainWindow.py
+++ b/src/windows/mainWindow/mainWindow.py
@@ -310,12 +310,16 @@ class MainWindow(Adw.ApplicationWindow):
         return False
 
     def show_info_toast(self, text: str) -> None:
-        toast = Adw.Toast(
-            title=text,
-            timeout=3,
-            priority=Adw.ToastPriority.NORMAL
-        )
-        self.toast_overlay.add_toast(toast)
+        # Callers include background threads (e.g. update_assets in main.py);
+        # construct and add the toast on the main loop thread only.
+        def _add_toast():
+            toast = Adw.Toast(
+                title=text,
+                timeout=3,
+                priority=Adw.ToastPriority.NORMAL
+            )
+            self.toast_overlay.add_toast(toast)
+        GLib.idle_add(_add_toast)
 
     def get_active_controller(self) -> DeckController:
         if not recursive_hasattr(self, "leftArea.deck_stack"): return


### PR DESCRIPTION
hey :)

I have been chasing a crash where StreamController dies with a silent SIGSEGV and no Python traceback, and found it comes from GTK4 widget calls made off the main loop thread. I believe this is the same failure class that #566 fixed for MediaPlayerThread; this PR covers three remaining sites:

1. `DeckManager.remove_controller()` is called from `FlatpakDeckDisconnectThread` / udev callbacks; `deck_stack.remove_page()` now goes through `GLib.idle_add`, mirroring how `add_newly_connected_deck()` already handles `add_page()`.
2. `MainWindow.show_info_toast()` has background-thread callers (e.g. `update_assets` in main.py); the `Adw.Toast` is now constructed and added on the main loop.
3. `MissingRow.hide_install_error()` runs on a `threading.Timer` thread; its four widget calls are now dispatched via `GLib.idle_add`.

I have been running these patches on my own machine (Stream Deck +, flatpak, on the beta.14 base) since early June and the disconnect-path crash has not recurred. Full disclosure, I did use Claude Code to help track this down and write the fix.

Happy to split this into separate PRs or adjust anything, just let me know :)