### PR TITLE
Hold Gio.Application while keep-running is enabled (silent idle-quit in background mode)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -58,6 +58,20 @@ import globals as gl
 class App(Adw.Application):
     def __init__(self, deck_manager, **kwargs):
         super().__init__(**kwargs)
+        # Hold the application when running with keep-running enabled:
+        # closing the main window only hides it, and without a hold
+        # Gio.Application's lifecycle can idle-quit the process silently.
+        self._held = False
+        try:
+            _keep_running = gl.settings_manager.get_app_settings().get("system", {}).get("keep-running")
+            if _keep_running:
+                self.hold()
+                self._held = True
+        except Exception:
+            # If settings aren't ready yet, default to holding; the worst
+            # case is the app stays alive until explicit on_quit().
+            self.hold()
+            self._held = True
         self.deck_manager = deck_manager
 
         self.register_sigint_handler()
@@ -228,6 +242,12 @@ class App(Adw.Application):
         # Close all decks
         gl.deck_manager.close_all()
         # Stop timer
+        # Balance the self.hold() from __init__ so Gio.Application can clean up.
+        if getattr(self, "_held", False):
+            try:
+                self.release()
+            except Exception:
+                pass
         log.success("Stopped StreamController. Have a nice day!")
         log.stop()
         sys.exit(0)

--- a/src/app.py
+++ b/src/app.py
@@ -64,14 +64,11 @@ class App(Adw.Application):
         self._held = False
         try:
             _keep_running = gl.settings_manager.get_app_settings().get("system", {}).get("keep-running")
-            if _keep_running:
-                self.hold()
-                self._held = True
+            self.set_keep_running_hold(bool(_keep_running))
         except Exception:
             # If settings aren't ready yet, default to holding; the worst
             # case is the app stays alive until explicit on_quit().
-            self.hold()
-            self._held = True
+            self.set_keep_running_hold(True)
         self.deck_manager = deck_manager
 
         self.register_sigint_handler()
@@ -99,6 +96,17 @@ class App(Adw.Application):
             self.style_manager.set_color_scheme(Adw.ColorScheme.PREFER_DARK)
         else:
             self.style_manager.set_color_scheme(Adw.ColorScheme.FORCE_DARK) # Not everything looks good in light mode at the moment #TODO
+
+    def set_keep_running_hold(self, keep_running: bool) -> None:
+        # Keeps the Gio.Application hold in sync with the keep-running
+        # setting, including when it is toggled while the app is already
+        # running (e.g. from the settings page or the KeepRunningDialog).
+        if keep_running and not self._held:
+            self.hold()
+            self._held = True
+        elif not keep_running and self._held:
+            self.release()
+            self._held = False
 
     def on_activate(self, app):
         log.trace("running: on_activate")
@@ -242,12 +250,8 @@ class App(Adw.Application):
         # Close all decks
         gl.deck_manager.close_all()
         # Stop timer
-        # Balance the self.hold() from __init__ so Gio.Application can clean up.
-        if getattr(self, "_held", False):
-            try:
-                self.release()
-            except Exception:
-                pass
+        # Balance any outstanding hold so Gio.Application can clean up.
+        self.set_keep_running_hold(False)
         log.success("Stopped StreamController. Have a nice day!")
         log.stop()
         sys.exit(0)

--- a/src/windows/Settings/Settings.py
+++ b/src/windows/Settings/Settings.py
@@ -746,6 +746,11 @@ class SystemGroup(Adw.PreferencesGroup):
         # Save
         self.settings.save_json()
 
+        # Keep the Gio.Application hold in sync so the change applies
+        # immediately, without requiring an app restart.
+        if hasattr(gl, "app"):
+            gl.app.set_keep_running_hold(self.keep_running.get_active())
+
     def on_autostart_toggled(self, *args):
         self.settings.settings_json.setdefault("system", {})
         self.settings.settings_json["system"]["autostart"] = self.autostart.get_active()

--- a/src/windows/mainWindow/elements/KeepRunningDialog.py
+++ b/src/windows/mainWindow/elements/KeepRunningDialog.py
@@ -54,6 +54,11 @@ class KeepRunningDialog(Adw.MessageDialog):
         app_settings["system"]["keep-running"] = keep_runnning
         gl.settings_manager.save_app_settings(app_settings)
 
+        # Keep the Gio.Application hold in sync so the choice takes effect
+        # immediately for this session.
+        if hasattr(gl, "app"):
+            gl.app.set_keep_running_hold(keep_runnning)
+
         if callable(self.callback):
             self.callback(keep_runnning)
 


### PR DESCRIPTION
hey :)

With keep-running enabled, closing the main window only hides it, and Gio.Application's reference counting can then decide the app is idle and quit the process silently. The deck goes dark with no traceback and no log line, which makes it look like a crash.

This holds the application in `__init__` while keep-running is active and releases it in `on_quit()`, so the lifecycle is pinned to the explicit quit path. I believe #558 reworks this area more broadly; this is meant as the minimal bugfix for current main, and I am happy to close it if that lands first.

I have been running this since late May with the app in background mode daily and have not seen the silent quit since. Full disclosure, I did use Claude Code to help with this.

Let me know if you would like anything changed :)