### PR TITLE
add logind lock screen detection for Niri

### DIFF
--- a/src/backend/LockScreenManager/Detectors/Logind.py
+++ b/src/backend/LockScreenManager/Detectors/Logind.py
@@ -1,0 +1,65 @@
+from src.backend.LockScreenManager.LockScreenDetector import LockScreenDetector
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from src.backend.LockScreenManager.LockScreenManager import LockScreenManager
+
+import os
+
+# Import globals first to get IS_MAC
+import globals as gl
+
+if not gl.IS_MAC:
+    import dbus
+
+from loguru import logger as log
+
+class LogindLockScreenDetector(LockScreenDetector):
+    def __init__(self, lock_screen_manager: "LockScreenManager"):
+        self.lock_screen_manager: "LockScreenManager" = lock_screen_manager
+
+        self.setup_dbus()
+
+    def on_lock(self):
+        self.lock_screen_manager.lock(True)
+
+    def on_unlock(self):
+        self.lock_screen_manager.lock(False)
+
+    def setup_dbus(self):
+        if gl.IS_MAC:
+            return
+
+        # Use the D-Bus MainLoop with glib integration
+        dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+
+        # Connect to the System Bus
+        bus = dbus.SystemBus()
+
+        # Resolve the session path for the current user session
+        session_path = self._resolve_session_path(bus)
+
+        log.info(f"Logind lock detector active ({session_path})")
+
+        session_obj = bus.get_object("org.freedesktop.login1", session_path)
+        session_obj.connect_to_signal(
+            "Lock", self.on_lock,
+            dbus_interface="org.freedesktop.login1.Session"
+        )
+        session_obj.connect_to_signal(
+            "Unlock", self.on_unlock,
+            dbus_interface="org.freedesktop.login1.Session"
+        )
+
+    def _resolve_session_path(self, bus) -> str:
+        manager = bus.get_object("org.freedesktop.login1", "/org/freedesktop/login1")
+        manager_iface = dbus.Interface(manager, "org.freedesktop.login1.Manager")
+
+        session_id = os.environ.get("XDG_SESSION_ID")
+        if session_id:
+            try:
+                return manager_iface.GetSession(session_id)
+            except dbus.DBusException as e:
+                log.warning(f"Failed to resolve logind session via XDG_SESSION_ID={session_id}: {e}")
+
+        return manager_iface.GetSessionByPID(os.getpid())

--- a/src/backend/LockScreenManager/LockScreenManager.py
+++ b/src/backend/LockScreenManager/LockScreenManager.py
@@ -18,6 +18,7 @@ from src.backend.LockScreenManager.Detectors.Gnome import GnomeLockScreenDetecto
 from src.backend.LockScreenManager.Detectors.Cinnamon import CinnamonLockScreenDetector
 from src.backend.LockScreenManager.Detectors.KDE import KDELockScreenDetector
 from src.backend.LockScreenManager.Detectors.Hyprland import HyprlandLockScreenDetector
+from src.backend.LockScreenManager.Detectors.Logind import LogindLockScreenDetector
 from src.backend.LockScreenManager.LockScreenDetector import LockScreenDetector
 from loguru import logger as log
 
@@ -32,14 +33,26 @@ class LockScreenManager:
     @log.catch
     def setup(self):
         env = self.get_active_environment()
+
+        # Hyprland uses the Wayland lock notifier protocol directly
+        if env == "hyprland":
+            self.detector = HyprlandLockScreenDetector(self)
+            return
+
+        # Try logind
+        try:
+            self.detector = LogindLockScreenDetector(self)
+            return
+        except Exception as e:
+            log.debug(f"Logind lock detection not available: {e}")
+
+        # Fall back to DE-specific DBus detectors
         if env == "gnome":
             self.detector = GnomeLockScreenDetector(self)
         elif env == "x-cinnamon":
             self.detector = CinnamonLockScreenDetector(self)
         elif env == "kde":
             self.detector = KDELockScreenDetector(self)
-        elif env == "hyprland":
-            self.detector = HyprlandLockScreenDetector(self)
 
     @log.catch
     def get_active_environment(self) -> str:

--- a/src/windows/Settings/Settings.py
+++ b/src/windows/Settings/Settings.py
@@ -719,7 +719,7 @@ class SystemGroup(Adw.PreferencesGroup):
         self.autostart = Adw.SwitchRow(title=gl.lm.get("settings-system-settings-autostart"), subtitle=gl.lm.get("settings-system-settings-autostart-subtitle"), active=True)
         self.add(self.autostart)
 
-        self.lock_on_lock_screen = Adw.SwitchRow(title="Lock decks when screen is locked", subtitle="Works on Gnome, KDE, Cinnamon and Hyprland", active=True)
+        self.lock_on_lock_screen = Adw.SwitchRow(title="Lock decks when screen is locked", subtitle="Works on Gnome, KDE, Cinnamon, Hyprland, and Niri", active=True)
         self.add(self.lock_on_lock_screen)
 
         self.beta_resume_mode = Adw.SwitchRow(title="Use new resume mode (beta)", subtitle="Use new way to resume after suspends - requires restart", active=False)


### PR DESCRIPTION
The current lock screen detection doesn't support [Niri](https://github.com/niri-wm/niri).

This PR adds support for it by trying lock screen detection via logind, This should also work on Gnome or KDE, but their specific detection is left untouched as a fallback.

Tested locally on NixOS with an overlay [overlay-test-diff.md](https://github.com/user-attachments/files/30380808/overlay-test-diff.md), basically replacing these 3 files before rebuilding.