### PR TITLE
Fix page import and cached-page reload callbacks

### DIFF
--- a/src/backend/PageManagement/PageManagerBackend.py
+++ b/src/backend/PageManagement/PageManagerBackend.py
@@ -337,7 +337,7 @@ class PageManagerBackend:
             if page.deck_controller.active_page != page:
                 continue
 
-            page.deck_controller.load_page(page, allow_relaod=True,
+            page.deck_controller.load_page(page, allow_reload=True,
                                            load_brightness=brightness,
                                            load_screensaver=screensaver,
                                            load_background=background,

--- a/src/windows/PageManager/elements/MenuButton.py
+++ b/src/windows/PageManager/elements/MenuButton.py
@@ -152,7 +152,7 @@ class MenuButton(Gtk.MenuButton):
 
         self.selected_file = None
 
-        page_name = os.path.splitext(os.path.basename(page_path))[0]
+        page_name = name
         try:
             page_path = gl.page_manager.add_page(page_name, import_dict)
         except FileExistsError:


### PR DESCRIPTION
## Summary

- use the validated import/duplicate callback name when adding a page
- fix the `allow_reload` keyword used for active cached-page reloads

## Problem

`import_page_name_selected_callback` currently reads its local `page_path`
before assigning it. Both page import and duplicate reach that callback, so
they fail with `UnboundLocalError`.

`reload_pages_with_path` passes `allow_relaod` to
`DeckController.load_page`, whose supported parameter is `allow_reload`.
Reloading an active cached page therefore fails with `TypeError`.

## Verification

- both changed modules compile
- page import callback regression harness preserves the validated name, JSON
  document, selector-row update, and `PageAdd` signal
- cached-page regression harness preserves the active-page guard and all reload
  flags while passing `allow_reload=True`
