### PR TITLE
Bump nltk from 3.9.1 to 3.10.0 (security fixes)

### DIFF
--- a/requirement_macos.txt
+++ b/requirement_macos.txt
@@ -47,7 +47,7 @@ memray==1.15.0
 meson==1.7.0
 meson-python==0.17.1
 natsort==8.4.0
-nltk==3.9.1
+nltk==3.10.0
 numpy==2.2.3
 opencv-python==4.11.0.86
 packaging==24.2


### PR DESCRIPTION
Bumps `nltk` from 3.9.1 to 3.10.0 in `requirement_macos.txt`.

**Security context:** nltk 3.9.1 is affected by 28 known vulnerabilities tracked in the OSV database, including multiple path traversal issues, SSRF bypasses, ReDoS, and arbitrary file read/write. Version 3.10.0 resolves all of them and currently reports zero known vulnerabilities.

**Advisories cleared by this bump (fixed in 3.10.0):**
- GHSA-m42h-3232-vpv3 (CVE-2026-12243) — path traversal via percent-encoded sequences in `nltk.data.load()`
- GHSA-469j-vmhf-r6v7 — path traversal / arbitrary file overwrite in Downloader
- GHSA-68j8-pq59-fqgm — path traversal
- GHSA-6hm5-jgcp-p838 — path traversal in NKJPCorpusReader
- GHSA-p4gq-832x-fm9v — URL-encoded path traversal in `nltk.data.load()`
- GHSA-qvv7-cg9c-w4x3 — DNS-rebinding SSRF filter bypass in `nltk.pathsec.urlopen`
- GHSA-xh95-f55m-82fw — path traversal in `FramenetCorpusReader.frame()`
- GHSA-fg7f-2386-8897 — ReDoS in ReviewsCorpusReader
- PYSEC-2026-2078, PYSEC-2026-3581–3584

**Scanner verification:**
- Before: OSV query for `nltk==3.9.1` returned 28 vulnerabilities
- After: OSV query for `nltk==3.10.0` returned 0 vulnerabilities

**Scope:** Only `requirement_macos.txt` changed. No application code, no logic changes. nltk is not directly imported anywhere in this repository's source code.