### PR TITLE
fix: Treat a title-less window as a window change on KDE

### DIFF
--- a/src/backend/WindowGrabber/Integrations/KDE.py
+++ b/src/backend/WindowGrabber/Integrations/KDE.py
@@ -134,8 +134,17 @@ class KDE(Integration):
             if kdotool is None:
                 return
             title = kdotool.communicate()[0].decode().strip()
-            if title is None or len(title) < 2:
+            if title is None:
                 return
+            if title == "":
+                # When the desktop (plasmashell) has an empty title and
+                # rejecting it means minimising every window is never seen as a
+                # window change, so auto-change pages never fall back.
+                time.sleep(0.1)
+                kdotool = self._run_command(["kdotool", "getwindowname", window_id])
+                if kdotool is None:
+                    return
+                title = kdotool.communicate()[0].decode().strip()
             return title
         except CalledProcessError as e:
             log.error(f"An error occurred while running kdotool: {e}")


### PR DESCRIPTION
get_title() rejected any title under two characters, and the desktop window (plasmashell) has an empty title. Minimising every window therefore emitted no active-window-changed event at all, so pages configured to auto-change never fell back to the default page once a match had been made.

Accept an empty title, but re-query once first: a window that is still mapping also reports an empty title briefly, and treating that transient state as the desktop would load the wrong page.